### PR TITLE
Added support for IPv6 Neighbor Advertisement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: neighsnoopd
 neighsnoopd.bpf.c:
 
 neighsnoopd.bpf.o: neighsnoopd.bpf.c neighsnoopd_shared.h
-	clang -O2 -g -target bpf -c neighsnoopd.bpf.c -o neighsnoopd.bpf.o -I/usr/include/x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/asm -I/usr/include/x86_64-linux-gnu/gnu
+	clang -Wall -O2 -g -target bpf -c neighsnoopd.bpf.c -o neighsnoopd.bpf.o -I/usr/include/x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/asm -I/usr/include/x86_64-linux-gnu/gnu
 
 neighsnoopd.bpf.skel.h: neighsnoopd.bpf.o
 	bpftool gen skeleton neighsnoopd.bpf.o > neighsnoopd.bpf.skel.h
@@ -22,7 +22,7 @@ $(VERSION_FILE):
 	@echo $(VERSION_DEFINE) > $(VERSION_FILE)
 
 neighsnoopd: neighsnoopd.bpf.skel.h neighsnoopd.c neighsnoopd.h neighsnoopd_shared.h $(VERSION_FILE)
-	gcc -Wall -o neighsnoopd neighsnoopd.c logging.c -lbpf -lmnl
+	gcc -g -Wall -o neighsnoopd neighsnoopd.c lib.c logging.c -lbpf -lmnl
 
 clean:
 	rm -f neighsnoopd.bpf.o neighsnoopd.bpf.skel.h neighsnoopd cscope.in.out cscope.out cscope.po.out $(VERSION_FILE)

--- a/lib.c
+++ b/lib.c
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-FileCopyrightText: 2024 1984 <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
+/* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
+
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include "neighsnoopd.h"
+
+
+void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size)
+{
+    if (buffer_size < MAC_ADDR_STR_LEN) { // "XX:XX:XX:XX:XX:XX" + null terminator
+        buffer[0] = '\0'; // Not enough space, return an empty string
+        return;
+    }
+    snprintf((char *)buffer, buffer_size, "%02x:%02x:%02x:%02x:%02x:%02x",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+void calculate_network_address(const struct in6_addr *ip,
+                               const struct in6_addr *netmask,
+                               struct in6_addr *network)
+{
+    for (int i = 0; i < 16; i++)
+        network->s6_addr[i] = ip->s6_addr[i] & netmask->s6_addr[i];
+}
+
+int compare_ipv6_addresses(const struct in6_addr *addr1,
+                           const struct in6_addr *addr2)
+{
+    return memcmp(addr1, addr2, sizeof(struct in6_addr)) == 0;
+}
+
+/*
+ * Handle printing IPv4 addresses without the ::ffff: prefix
+ */
+int format_ip_address(char *buf, size_t size, const struct in6_addr *addr)
+{
+    if (IN6_IS_ADDR_V4MAPPED(addr))
+        return inet_ntop(AF_INET, &addr->s6_addr[12], buf, size) == 0;
+    else
+        return inet_ntop(AF_INET6, addr, buf, size) == 0;
+}
+
+/*
+ * Function to calculate the CIDR of an IPv6 address
+ */
+int calculate_cidr(const struct in6_addr *addr) {
+    int cidr = 0;
+
+    // Check if the address is an IPv4-mapped IPv6 address
+    if (IN6_IS_ADDR_V4MAPPED(addr)) {
+        // Extract the IPv4 part (last 4 bytes)
+        struct in_addr ipv4_addr;
+        memcpy(&ipv4_addr, &addr->s6_addr[12], sizeof(ipv4_addr));
+
+        cidr = __builtin_popcount(ntohl(ipv4_addr.s_addr));
+    } else {
+        // Count the number of set bits in the IPv6 address
+        for (int i = 0; i < 4; i++)
+            cidr += __builtin_popcountl(addr->__in6_u.__u6_addr32[i]);
+    }
+    return cidr;
+}

--- a/neighsnoopd.bpf.c
+++ b/neighsnoopd.bpf.c
@@ -18,33 +18,115 @@
 
 #include "neighsnoopd_shared.h"
 
+#define ND_NEIGHBOR_ADVERT          136
+#define ND_OPT_MAX_CHAIN            3
+#define ND_OPT_TARGET_LINKADDR      2
+
+struct nd_opt_hdr {
+    __u8 nd_opt_type;
+    __u8 nd_opt_len; // Length in units of 8 octets
+};
+
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 24);  // 16 MB
-} arp_ringbuf SEC(".maps");
+} neighbor_ringbuf SEC(".maps");
 
-static __always_inline struct arp_reply *handle_arp_reply(
-    void *data, void *data_end)
+// Find ND Option Header of specified type
+static __always_inline int find_nd_opt(struct hdr_cursor *nh,
+                                       void *data_end,
+                                       __u8 next_hdr_type)
 {
-        struct collect_vlans vlans = { 0 };
-    struct ethhdr *eth;
+    for (int i = 0; i < ND_OPT_MAX_CHAIN; ++i) {
+        struct nd_opt_hdr *hdr = nh->pos;
+
+        if ((void *)(hdr + 1) > data_end)
+            return -1;
+
+        if (((void *)hdr) + hdr->nd_opt_len * 8 > data_end)
+            return -1;
+
+        switch (hdr->nd_opt_type) {
+            case ND_OPT_TARGET_LINKADDR:
+                return 0;
+            default:
+                nh->pos = ((void *)hdr) + hdr->nd_opt_len * 8;
+        }
+    }
+
+    return -1;
+}
+
+static __always_inline struct neighbor_reply *handle_nd_reply(
+    struct hdr_cursor *nh, void *data_end, struct ethhdr *eth)
+{
+    struct neighbor_reply *neighbor_reply = NULL;
+    struct ipv6hdr *ip;
+    struct icmp6hdr *icmp6;
+    struct in6_addr *target_ipv6;
+    struct nd_opt_hdr *nd_opt_hdr;
+    __u8 *target_mac;
+
+    // Parse the IPv6 header
+    if (parse_ip6hdr(nh, data_end, &ip) != IPPROTO_ICMPV6)
+        goto out;
+
+    // Check if the message is a Neighbor Advertisement
+    if (parse_icmp6hdr(nh, data_end, &icmp6) != ND_NEIGHBOR_ADVERT)
+        goto out;
+
+    if ((void *)(icmp6 + 1) > data_end)
+        goto out;
+    nh->pos = icmp6 + 1;
+
+    // Check if the message is long enough to contain the target IPv6 address
+    target_ipv6 = nh->pos;
+    if ((void *)(target_ipv6 + 1) > data_end)
+        goto out;
+    nh->pos = target_ipv6 + 1;
+
+    // Parse options to find the Source Link-Layer Address (MAC address)
+    if (find_nd_opt(nh, data_end, ND_OPT_TARGET_LINKADDR)) {
+        target_mac = eth->h_source;
+    } else {
+        nd_opt_hdr = nh->pos;
+
+        if ((void *)(nd_opt_hdr + 1) > data_end)
+            goto out;
+
+        target_mac = (void *)(nd_opt_hdr + 1);
+
+        if ((void *)(target_mac + ETH_ALEN) > data_end)
+            goto out;
+    }
+
+    // Add the data to the ringbuffer
+    neighbor_reply = bpf_ringbuf_reserve(&neighbor_ringbuf,
+                                         sizeof(*neighbor_reply), 0);
+    if (!neighbor_reply)
+        goto out;
+
+    __builtin_memcpy(neighbor_reply->mac, target_mac, ETH_ALEN);
+    __builtin_memcpy(&neighbor_reply->ip, target_ipv6, sizeof(*target_ipv6));
+
+    neighbor_reply->in_family = AF_INET6;
+
+out:
+    return neighbor_reply;
+}
+
+static __always_inline struct neighbor_reply *handle_arp_reply(
+    struct hdr_cursor *nh, void *data_end)
+{
+    struct neighbor_reply *neighbor_reply = NULL;
     struct arphdr *arp;
-    int eth_type;
     __u8 *sender_ip;
     __u8 *sender_mac;
-    struct arp_reply *arp_reply = NULL;
 
-    struct hdr_cursor nh;
-    nh.pos = data;
-
-    eth_type = parse_ethhdr_vlan(&nh, data_end, &eth, &vlans);
-    if (eth_type != bpf_htons(ETH_P_ARP))
+    if (nh->pos + sizeof(struct arphdr) > data_end)
         goto out;
 
-    if (nh.pos + sizeof(struct arphdr) > data_end)
-        goto out;
-
-    arp = nh.pos;
+    arp = nh->pos;
     if (arp->ar_op != bpf_htons(ARPOP_REPLY))
         goto out;
 
@@ -57,57 +139,87 @@ static __always_inline struct arp_reply *handle_arp_reply(
     if (sender_ip + 4 > (__u8 *)data_end)
         goto out;
 
-    arp_reply = bpf_ringbuf_reserve(&arp_ringbuf, sizeof(*arp_reply), 0);
-    if (!arp_reply)
+    // Add the data to the ringbuffer
+    neighbor_reply = bpf_ringbuf_reserve(&neighbor_ringbuf,
+                                         sizeof(*neighbor_reply), 0);
+    if (!neighbor_reply)
         goto out;
 
-    __builtin_memcpy(arp_reply->mac, sender_mac, ETH_ALEN);
-    __builtin_memcpy(arp_reply->ip_bytes, sender_ip,
-             sizeof(arp_reply->ip_bytes));
-    arp_reply->vlan_id = vlans.id[0];
+    __builtin_memcpy(neighbor_reply->mac, sender_mac, ETH_ALEN);
+    map_ipv4_to_ipv6(&neighbor_reply->ip, *(__be32 *)sender_ip);
+
+    neighbor_reply->in_family = AF_INET;
 
 out:
-    return  arp_reply;
+    return neighbor_reply;
 }
 
+static __always_inline struct neighbor_reply *handle_neighbor_reply(
+    void *data, void *data_end)
+{
+    struct neighbor_reply *neighbor_reply = NULL;
+    struct collect_vlans vlans = { 0 };
+    struct ethhdr *eth;
+    int eth_type;
+    struct hdr_cursor nh;
+    nh.pos = data;
+
+    eth_type = parse_ethhdr_vlan(&nh, data_end, &eth, &vlans);
+    if (eth_type == bpf_htons(ETH_P_IPV6))
+        neighbor_reply = handle_nd_reply(&nh, data_end, eth);
+    else if (eth_type == bpf_htons(ETH_P_ARP))
+        neighbor_reply = handle_arp_reply(&nh, data_end);
+    else
+        goto out;
+
+    if (!neighbor_reply)
+        goto out;
+
+    neighbor_reply->vlan_id = vlans.id[0];
+
+out:
+    return neighbor_reply;
+}
 
 SEC("xdp")
-int handle_arp_reply_xdp(struct xdp_md *ctx)
+int handle_neighbor_reply_xdp(struct xdp_md *ctx)
 {
     void *data_end = (void *)(unsigned long long)ctx->data_end;
     void *data = (void *)(unsigned long long)ctx->data;
 
-    struct arp_reply *arp_reply = handle_arp_reply(data, data_end);
+    struct neighbor_reply *neighbor_reply = handle_neighbor_reply(data,
+                                                                  data_end);
 
-    if (!arp_reply)
+    if (!neighbor_reply)
         goto out;
 
-    arp_reply->ingress_ifindex = ctx->ingress_ifindex;
+    neighbor_reply->ingress_ifindex = ctx->ingress_ifindex;
 
     // Send the data to userspace
-    bpf_ringbuf_submit(arp_reply, 0);
+    bpf_ringbuf_submit(neighbor_reply, 0);
 out:
     return XDP_PASS;
 }
 
 SEC("tc")
-int handle_arp_reply_tc(struct __sk_buff *skb)
+int handle_neighbor_reply_tc(struct __sk_buff *skb)
 {
     void *data_end = (void *)(unsigned long long)skb->data_end;
     void *data = (void *)(unsigned long long)skb->data;
 
-    struct arp_reply *arp_reply = handle_arp_reply(data, data_end);
+    struct neighbor_reply *neighbor_reply = handle_neighbor_reply(data,
+                                                                  data_end);
 
-    if (!arp_reply)
+    if (!neighbor_reply)
         goto out;
 
-    arp_reply->ingress_ifindex = skb->ifindex;
+    neighbor_reply->ingress_ifindex = skb->ifindex;
 
-    arp_reply->vlan_id = skb->vlan_present ? skb->vlan_tci
+    neighbor_reply->vlan_id = skb->vlan_present ? skb->vlan_tci
         & VLAN_VID_MASK : 0;
 
     // Send the data to userspace
-    bpf_ringbuf_submit(arp_reply, 0);
+    bpf_ringbuf_submit(neighbor_reply, 0);
 out:
     return TC_ACT_OK;
 }

--- a/neighsnoopd.h
+++ b/neighsnoopd.h
@@ -11,7 +11,10 @@
 #include <stdbool.h>
 #include <linux/types.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #include <regex.h>
+
+#include <libmnl/libmnl.h>
 
 #define MAC_ADDR_STR_LEN 18
 
@@ -24,6 +27,8 @@ struct env {
     bool is_xdp;
     bool disable_macvlan_filter;
     bool fail_on_qfilter_present;
+    bool only_ipv4;
+    bool only_ipv6;
     bool verbose;
     bool debug;
     bool has_count;
@@ -32,6 +37,14 @@ struct env {
 };
 
 void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size);
+void calculate_network_address(const struct in6_addr *ip,
+                               const struct in6_addr *netmask,
+                               struct in6_addr *network);
+int compare_ipv6_addresses(const struct in6_addr *addr1,
+                           const struct in6_addr *addr2);
+int format_ip_address(char *buf, size_t size,
+                             const struct in6_addr *addr);
+int calculate_cidr(const struct in6_addr *addr);
 
 // Print functions
 void __pr_std(FILE * file, const char *format, ...);

--- a/neighsnoopd_shared.h
+++ b/neighsnoopd_shared.h
@@ -7,14 +7,22 @@
 #ifndef NEIGHSNOOPD_SHARED_H_
 #define NEIGHSNOOPD_SHARED_H_
 
-struct arp_reply {
+struct neighbor_reply {
     __be16 vlan_id;
-    union {
-        struct in_addr ip;
-        __u8 ip_bytes[4];
-    };
+    struct in6_addr ip;
+    __u8 in_family;
     __u8 mac[6];
     __u32 ingress_ifindex;
 };
+
+/*
+ * Maps an IPv4 address into an IPv6 address according to RFC 4291 sec 2.5.5.2
+ */
+static void map_ipv4_to_ipv6(struct in6_addr *ipv6, __be32 ipv4)
+{
+    __builtin_memset(((__u8 *)ipv6), 0x00, 10);
+    __builtin_memset(((__u8 *)ipv6) + 10, 0xff, 2);
+    ((__u32 *)ipv6)[3] = ipv4;
+}
 
 #endif // NEIGHSNOOPD_SHARED_H_


### PR DESCRIPTION
This version can handle IPv6 ND messages and ARP Replies. It also supports the -4 and -6 command-line options, forcing the program to handle only IPv4 or IPv6.

This version also adds a new file called lib.c with utility functions used by the program.