### PR TITLE
Moved to a fully event based system with caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+neighsnoop
 neighsnoopd
 version.in.h
 cscope.out

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ VERSION_FILE = version.in.h
 GIT_COMMIT_HASH = $(shell git rev-parse --short HEAD)
 VERSION_DEFINE = "\#define GIT_COMMIT \"$(GIT_COMMIT_HASH)\""
 
+GLIB_CFLAGS = $(shell pkg-config --cflags --libs glib-2.0)
+
 all: neighsnoopd
 
 neighsnoopd.bpf.c:
@@ -21,8 +23,8 @@ neighsnoopd.bpf.skel.h: neighsnoopd.bpf.o
 $(VERSION_FILE):
 	@echo $(VERSION_DEFINE) > $(VERSION_FILE)
 
-neighsnoopd: neighsnoopd.bpf.skel.h neighsnoopd.c neighsnoopd.h neighsnoopd_shared.h $(VERSION_FILE)
-	gcc -g -Wall -o neighsnoopd neighsnoopd.c lib.c logging.c -lbpf -lmnl
+neighsnoopd: neighsnoopd.bpf.skel.h neighsnoopd.c neighsnoopd.h neighsnoopd_shared.h netlink.c cache.c lib.c $(VERSION_FILE)
+	gcc -g -Wall -o neighsnoopd -D_GNU_SOURCE -I./include neighsnoopd.c netlink.c cache.c lib.c logging.c -lbpf -lmnl $(GLIB_CFLAGS)
 
 clean:
 	rm -f neighsnoopd.bpf.o neighsnoopd.bpf.skel.h neighsnoopd cscope.in.out cscope.out cscope.po.out $(VERSION_FILE)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION_DEFINE = "\#define GIT_COMMIT \"$(GIT_COMMIT_HASH)\""
 
 GLIB_CFLAGS = $(shell pkg-config --cflags --libs glib-2.0)
 
-all: neighsnoopd
+all: neighsnoopd neighsnoop
 
 neighsnoopd.bpf.c:
 
@@ -24,10 +24,13 @@ $(VERSION_FILE):
 	@echo $(VERSION_DEFINE) > $(VERSION_FILE)
 
 neighsnoopd: neighsnoopd.bpf.skel.h neighsnoopd.c neighsnoopd.h neighsnoopd_shared.h netlink.c cache.c lib.c $(VERSION_FILE)
-	gcc -g -Wall -o neighsnoopd -D_GNU_SOURCE -I./include neighsnoopd.c netlink.c cache.c lib.c logging.c -lbpf -lmnl $(GLIB_CFLAGS)
+	gcc -g -Wall -o neighsnoopd -D_GNU_SOURCE -I./include neighsnoopd.c netlink.c cache.c lib.c stats.c logging.c lib/json_writer.c -lbpf -lmnl $(GLIB_CFLAGS)
+
+neighsnoop: neighsnoop.c
+	gcc -g -Wall -o neighsnoop neighsnoop.c
 
 clean:
-	rm -f neighsnoopd.bpf.o neighsnoopd.bpf.skel.h neighsnoopd cscope.in.out cscope.out cscope.po.out $(VERSION_FILE)
+	rm -f neighsnoopd.bpf.o neighsnoopd.bpf.skel.h neighsnoopd neighsnoop cscope.in.out cscope.out cscope.po.out $(VERSION_FILE)
 
 cscope:
 	cscope -b -R -q

--- a/cache.c
+++ b/cache.c
@@ -1,0 +1,977 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-FileCopyrightText: 2024 - 1984 Hosting Company <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 - Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
+/* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
+
+#include <linux/bpf.h>
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <errno.h>
+#include <time.h>
+#include <linux/neighbour.h>
+
+#include "neighsnoopd.h"
+
+extern struct env env;
+
+GHashTable *db_lookup_addr; // Lookup network by network IP
+GHashTable *db_lookup_vlan_networkid; // Lookup link_network by
+                                      // network_id and vlan_id
+
+GHashTable *db_lookup_addr_ifindex; // Lookup network by network IP and ifindex
+
+GHashTable *db_link_cache;
+GHashTable *db_network_cache;
+GHashTable *db_fdb_cache;
+GHashTable *db_neigh_cache;
+
+static guint vlan_networkid_cache_key_hash(gconstpointer key)
+{
+    const struct vlan_networkid_cache_key *k = key;
+    guint hash = 0;
+
+    // Hash the Network ID
+    hash = hash * 31 + g_int_hash(&k->network_id);
+
+    // Hash the VLAN ID
+    hash = hash * 31 + g_int_hash(&k->vlan_id);
+
+    return hash;
+}
+
+static gboolean vlan_networkid_cache_key_equal(gconstpointer left,
+                                               gconstpointer right)
+{
+    const struct vlan_networkid_cache_key *key_left = left;
+    const struct vlan_networkid_cache_key *key_right = right;
+
+    // Compare Network ID
+    if (key_left->network_id != key_right->network_id)
+        return false;
+
+    // Compare VLAN IDs
+    if (key_left->vlan_id != key_right->vlan_id)
+        return false;
+
+    return true;
+}
+
+static guint addr_cache_key_hash(gconstpointer key)
+{
+    const struct in6_addr *k = key;
+    guint hash = 0;
+
+    // Hash the IP address
+    for (guint i = 0; i < sizeof(*k); i++)
+        hash = hash * 31 + k->s6_addr[i];
+
+    return hash;
+}
+
+static gboolean addr_cache_key_equal(gconstpointer left,
+                                          gconstpointer right)
+{
+    const struct in6_addr *key_left = left;
+    const struct in6_addr *key_right = right;
+
+    // Compare IP addresses
+    if (memcmp(key_left, key_right,
+               sizeof(*key_left)) != 0)
+        return false;
+
+    return true;
+}
+
+static guint ifindex_addr_key_hash(gconstpointer key)
+{
+    const struct ifindex_addr_cache_key *k = key;
+    guint hash = 0;
+
+    // Hash the IP address
+    for (guint i = 0; i < sizeof(k->network_ip); i++)
+        hash = hash * 31 + k->network_ip.s6_addr[i];
+
+    // Hash the ifindex
+    hash = hash * 31 + g_int_hash(&k->ifindex);
+
+    return hash;
+}
+
+static gboolean ifindex_addr_key_equal(gconstpointer left,
+                                       gconstpointer right)
+{
+    const struct ifindex_addr_cache_key *key_left = left;
+    const struct ifindex_addr_cache_key *key_right = right;
+
+    // Compare IP addresses
+    if (memcmp(&key_left->network_ip, &key_right->network_ip,
+               sizeof(key_left->network_ip)) != 0)
+        return false;
+
+    // Compare ifindex
+    if (key_left->ifindex != key_right->ifindex)
+        return false;
+
+    return true;
+}
+
+struct link_cache *cache_add_link(struct netlink_link_cmd *link_cmd)
+{
+    struct link_cache *cache = NULL;
+
+    cache = g_new0(struct link_cache, 1);
+    if (!cache) {
+        pr_err(errno, "g_new0");
+        goto out;
+    }
+
+    cache->ifindex = link_cmd->ifindex;
+    memcpy(cache->mac, link_cmd->mac, ETH_ALEN);
+    snprintf(cache->ifname, sizeof(cache->ifname), "%s", link_cmd->ifname);
+    snprintf(cache->kind, sizeof(cache->kind), "%s", link_cmd->kind);
+    snprintf(cache->slave_kind, sizeof(cache->slave_kind), "%s",
+             link_cmd->slave_kind);
+    cache->vlan_id = link_cmd->vlan_id;
+    cache->vlan_protocol = link_cmd->vlan_protocol;
+    cache->has_vlan = link_cmd->has_vlan;
+    cache->is_macvlan = link_cmd->is_macvlan;
+
+    cache->network_list = NULL;
+    cache->fdb_list = NULL;
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.created) == -1) {
+        pr_err(errno, "clock_gettime");
+        g_free(cache);
+        goto out;
+    }
+    cache->times.referenced = cache->times.created;
+    cache->times.updated = cache->times.created;
+
+    g_hash_table_insert(db_link_cache, &cache->ifindex, cache);
+
+out:
+    return cache;
+}
+
+int cache_update_link(struct link_cache *cache,
+                             struct netlink_link_cmd *link_cmd)
+{
+    bool updated = false;
+
+    // TODO: Handle IP and subnet changes
+
+    if (cache->link_ifindex != link_cmd->link_ifindex) {
+        pr_debug("Updated link_ifindex for NIC: %s from %d to %d\n",
+                 cache->ifname, cache->link_ifindex, link_cmd->link_ifindex);
+        cache->link_ifindex = link_cmd->link_ifindex;
+        updated = true;
+    }
+
+    if (strcmp(cache->ifname, link_cmd->ifname) != 0) {
+        pr_debug("Updated ifname for NIC: %s from %s to %s\n",
+                 cache->ifname, cache->ifname, link_cmd->ifname);
+        strncpy(cache->ifname, link_cmd->ifname, sizeof(cache->ifname));
+        updated = true;
+    }
+
+    if (memcmp(cache->mac, link_cmd->mac, ETH_ALEN) != 0) {
+        pr_debug("Updated MAC address for NIC: %s\n", cache->ifname);
+        memcpy(cache->mac, link_cmd->mac, ETH_ALEN);
+        updated = true;
+    }
+
+    if (strcmp(cache->kind, link_cmd->kind) != 0) {
+        pr_debug("Updated kind for NIC: %s from %s to %s\n",
+                 cache->ifname, cache->kind, link_cmd->kind);
+        strncpy(cache->kind, link_cmd->kind, sizeof(cache->kind));
+        updated = true;
+    }
+
+    if (strcmp(cache->slave_kind, link_cmd->slave_kind) != 0) {
+        pr_debug("Updated slave_kind for NIC: %s from %s to %s\n",
+                 cache->ifname, cache->slave_kind, link_cmd->slave_kind);
+        strncpy(cache->slave_kind, link_cmd->slave_kind, sizeof(cache->slave_kind));
+        updated = true;
+    }
+
+    if (cache->vlan_protocol != link_cmd->vlan_protocol) {
+        pr_debug("Updated vlan_protocol for NIC: %s from %d to %d\n",
+                 cache->ifname, cache->vlan_protocol, link_cmd->vlan_protocol);
+        cache->vlan_protocol = link_cmd->vlan_protocol;
+        updated = true;
+    }
+
+    if (cache->vlan_id != link_cmd->vlan_id) {
+        pr_debug("Updated vlan_id for NIC: %s from %d to %d\n",
+                 cache->ifname, cache->vlan_id, link_cmd->vlan_id);
+        cache->vlan_id = link_cmd->vlan_id;
+        updated = true;
+    }
+
+    if (cache->has_vlan != link_cmd->has_vlan) {
+        pr_debug("Updated has_vlan for NIC: %s from %d to %d\n",
+                 cache->ifname, cache->has_vlan, link_cmd->has_vlan);
+        cache->has_vlan = link_cmd->has_vlan;
+        updated = true;
+    }
+
+    if (cache->is_macvlan != link_cmd->is_macvlan) {
+        pr_debug("Updated is_macvlan for NIC: %s from %d to %d\n",
+                 cache->ifname, cache->is_macvlan, link_cmd->is_macvlan);
+        cache->is_macvlan = link_cmd->is_macvlan;
+        updated = true;
+    }
+
+    if (updated) {
+        if (clock_gettime(CLOCK_REALTIME, &cache->times.updated) == -1) {
+            pr_err(errno, "clock_gettime");
+            return errno;
+        }
+    }
+    return 0;
+}
+
+int cache_add_link_network(struct link_network_cache *link_network)
+{
+    int ret = 0;
+    struct vlan_networkid_cache_key *vnid_key;
+    struct ifindex_addr_cache_key *ifad_key;
+    struct network_cache *network = link_network->network;
+    struct link_cache *link = link_network->link;
+
+    // Handle the VLAN/Network ID lookup cache
+    vnid_key = g_new0(struct vlan_networkid_cache_key, 1);
+    if (!vnid_key) {
+        pr_err(errno, "g_new0");
+        ret = -errno;
+        goto out;
+    }
+    vnid_key->network_id = network->id,
+    vnid_key->vlan_id = link->vlan_id,
+
+    ifad_key = g_new0(struct ifindex_addr_cache_key, 1);
+    if (!ifad_key) {
+        g_free(vnid_key);
+        pr_err(errno, "g_new0");
+        ret = -errno;
+        goto out;
+    }
+    ifad_key->network_ip = network->network;
+    ifad_key->ifindex = link->ifindex;
+
+    g_hash_table_insert(db_lookup_vlan_networkid, vnid_key, link_network);
+    g_hash_table_insert(db_lookup_addr_ifindex, ifad_key, link_network);
+
+    // Network reference
+    network->links = g_list_append(network->links, link_network);
+    network->refcnt++;
+
+    // Link reference
+    link->network_list = g_list_append(link->network_list, link_network);
+
+out:
+    return ret;
+}
+
+static void cache_del_link_network(struct link_network_cache *link_network)
+{
+    struct network_cache *network = link_network->network;
+    struct link_cache *link = link_network->link;
+
+    // Handle the VLAN/Network cache
+    struct vlan_networkid_cache_key key = {
+        .network_id = network->id,
+        .vlan_id = link->vlan_id,
+    };
+    g_hash_table_remove(db_lookup_vlan_networkid, &key);
+
+    struct ifindex_addr_cache_key addr_key = {
+        .network_ip = network->network,
+        .ifindex = link->ifindex,
+    };
+    g_hash_table_remove(db_lookup_addr_ifindex, &addr_key);
+
+    // Network reference
+    for (GList *iter = network->links; iter; iter = g_list_next(iter)) {
+        struct link_network_cache *link_network_cache = iter->data;
+        if (link_network_cache == link_network) {
+            network->links = g_list_delete_link(network->links, iter);
+            break;
+        }
+    }
+
+    // Handle Link reference
+    for (GList *iter = link->network_list; iter; iter = g_list_next(iter)) {
+        struct network_cache *network_cache = iter->data;
+        if (network_cache == network) {
+            link->network_list = g_list_delete_link(link->network_list, iter);
+            break;
+        }
+    }
+
+    // Free the link network cache
+    g_free(link_network);
+
+    network->refcnt--;
+}
+
+struct link_cache *cache_get_link(__u32 ifindex)
+{
+    struct link_cache *cache;
+
+    cache = g_hash_table_lookup(db_link_cache, &ifindex);
+    if (!cache)
+        goto out;
+
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.referenced) == -1) {
+        pr_err(errno, "clock_gettime");
+        cache = NULL;
+        goto out;
+    }
+    cache->reference_count++;
+
+out:
+    return cache;
+}
+
+int cache_del_link(struct netlink_link_cmd *link_cmd)
+{
+    int ret = 0;
+    GList *iter;
+    struct link_cache *cache = g_hash_table_lookup(db_link_cache,
+                                                   &link_cmd->ifindex);
+    if (!cache) {
+        ret = -1;
+        goto out;
+    }
+
+    for (iter = cache->network_list; iter; iter = g_list_next(iter))
+        cache_del_link_network(iter->data);
+
+    for (iter = cache->fdb_list; iter; iter = g_list_next(iter)) {
+        struct fdb_cache *fdb = iter->data;
+        struct fdb_cache_key key = {
+            .ifindex = fdb->link->ifindex,
+            .vlan_id = fdb->vlan_id,
+        };
+        g_hash_table_remove(db_fdb_cache, &key);
+    }
+
+    g_hash_table_remove(db_link_cache, &link_cmd->ifindex);
+    g_free(cache);
+
+out:
+    return ret;
+}
+
+struct link_network_cache *cache_new_link_network(void)
+{
+    return g_new0(struct link_network_cache, 1);
+}
+
+struct link_network_cache *cache_get_link_network_by_reply(
+    struct neighbor_reply *neighbor_reply)
+{
+    struct link_network_cache *cache;
+    struct vlan_networkid_cache_key key = {
+        .network_id = neighbor_reply->network_id,
+        .vlan_id = neighbor_reply->vlan_id,
+    };
+
+    cache = g_hash_table_lookup(db_lookup_vlan_networkid, &key);
+
+    return cache;
+}
+
+struct link_network_cache *cache_get_link_network_by_addr(
+    struct link_cache *link, struct in6_addr *ip)
+{
+    struct link_network_cache *cache;
+    struct in6_addr network_addr;
+
+    char ip_str[INET6_ADDRSTRLEN];
+    format_ip_address(ip_str, sizeof(ip_str), ip);
+
+    for (GList *iter = link->network_list; iter; iter = g_list_next(iter)) {
+        cache = iter->data;
+
+        network_addr = calculate_network_using_cidr(ip, cache->network->prefixlen);
+
+        if (compare_ipv6_addresses(&network_addr, &cache->network->network))
+            return cache;
+    }
+
+    return NULL;
+}
+
+struct link_network_cache *cache_get_link_network(int ifindex,
+                                                  struct in6_addr network_ip)
+{
+    struct ifindex_addr_cache_key key = {
+        .network_ip = network_ip,
+        .ifindex = ifindex,
+    };
+
+    return g_hash_table_lookup(db_lookup_addr_ifindex, &key);
+}
+
+struct network_cache *cache_add_network(struct netlink_addr_cmd *addr_cmd)
+{
+    struct network_cache *cache = NULL;
+    struct link_cache *link_cache;
+    struct link_network_cache *link_network_cache;
+    struct in6_addr *addr_key;
+    struct network_entry key;
+    struct network_value value = {0};
+
+    static __u32 id = 1;
+
+    link_cache = cache_get_link(addr_cmd->ifindex);
+    if (!link_cache) {
+        pr_err(0, "Link cache: Lookup: NIC: %d > Not found\n",
+               addr_cmd->ifindex);
+        goto err0;
+    }
+
+    cache = g_new0(struct network_cache, 1);
+    if (!cache) {
+        pr_err(errno, "g_new0");
+        goto err0;
+    }
+
+    link_network_cache = g_new0(struct link_network_cache, 1);
+    if (!link_network_cache) {
+        pr_err(errno, "g_new0");
+        goto err1;
+    }
+
+    cache->id = id++;
+    cache->network = addr_cmd->network;
+    cache->prefixlen = addr_cmd->prefixlen;
+    cache->true_prefixlen = addr_cmd->true_prefixlen;
+    format_ip_address(cache->network_str, sizeof(cache->network_str),
+                      &cache->network);
+
+    // Add to the network cache
+    g_hash_table_insert(db_network_cache, &cache->id, cache);
+
+    // Add to the network address lookup cache
+    addr_key = g_new0(struct in6_addr, 1);
+    if (!addr_key) {
+        pr_err(errno, "g_new0");
+        goto err2;
+    }
+    *addr_key = cache->network;
+    g_hash_table_insert(db_lookup_addr, addr_key, cache);
+
+    // Add link_network
+    link_network_cache->ip = addr_cmd->ip;
+    link_network_cache->network = cache;
+    link_network_cache->link = link_cache;
+    cache_add_link_network(link_network_cache);
+
+    // Add the network to the eBPF
+    key.prefixlen = cache->prefixlen;
+    memcpy(&key.network, &cache->network, sizeof(cache->network));
+
+    value.network_id = cache->id;
+
+    if (bpf_map_update_elem(env.target_networks_fd, &key, &value,
+                            BPF_ANY) < 0) {
+        pr_err(errno, "bpf_map_update_elem");
+        goto err3;
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.created) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto err3;
+    }
+    cache->times.referenced = cache->times.created;
+
+    return cache;
+err3:
+    g_hash_table_remove(db_lookup_addr, addr_key);
+    g_free(addr_key);
+err2:
+    g_hash_table_remove(db_network_cache, &cache->id);
+err1:
+    g_free(cache);
+err0:
+    return NULL;
+}
+
+struct network_cache *cache_get_network_by_id(__u32 network_id)
+{
+    struct network_cache *cache = NULL;
+
+    cache = g_hash_table_lookup(db_network_cache, &network_id);
+    if (!cache)
+        goto out;
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.referenced) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto out;
+    }
+    cache->reference_count++;
+
+out:
+    return cache;
+}
+
+struct network_cache *cache_get_network(struct netlink_addr_cmd *addr_cmd)
+{
+    return g_hash_table_lookup(db_lookup_addr, &addr_cmd->network);
+}
+
+int cache_del_network(struct netlink_addr_cmd *addr_cmd)
+{
+    int ret = 0;
+    struct link_cache *link_cache;
+    GList *iter;
+    struct network_cache *network;
+    struct link_network_cache *link_network;
+    struct ifindex_addr_cache_key addr_key;
+    struct network_entry key = {0};
+    bool found = false;
+
+    link_cache = cache_get_link(addr_cmd->ifindex);
+    if (!link_cache)
+        goto out;
+
+    // Find network from the CIDR network address
+    for (iter = link_cache->network_list; iter; iter = g_list_next(iter)) {
+        link_network = iter->data;
+        network = link_network->network;
+        if (compare_ipv6_addresses(&network->network, &addr_cmd->ip) &&
+            network->prefixlen == addr_cmd->prefixlen) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found)
+        goto out;
+
+    // Remove network id lookup cache
+    g_hash_table_remove(db_network_cache, &network->id);
+
+    // Remove the network address lookup cache
+    addr_key.network_ip = network->network;
+    g_hash_table_remove(db_lookup_addr, &addr_key);
+
+    // Remove all link/network links
+    for (iter = network->links; iter; iter = g_list_next(iter))
+        cache_del_link_network(iter->data);
+
+    // Remove the network from the eBPF
+    key.prefixlen = addr_cmd->prefixlen;
+    memcpy(&key.network, &addr_cmd->ip, sizeof(addr_cmd->ip));
+
+    if (bpf_map_delete_elem(env.target_networks_fd, &key) < 0) {
+        pr_err(errno, "bpf_map_delete_elem");
+        ret = errno;
+    }
+
+out:
+    return ret;
+}
+
+static guint fdb_cache_key_hash(gconstpointer key) {
+    const struct fdb_cache_key *k = key;
+    guint hash = 0;
+
+    // Hash the MAC address (treat as binary data)
+    for (guint i = 0; i < ETH_ALEN; i++)
+        hash = hash * 31 + k->mac[i];
+
+    // Hash the ifindex
+    hash = hash * 31 + g_int_hash(&k->ifindex);
+
+    // Hash the VLAN ID
+    hash = hash * 31 + g_int_hash(&k->vlan_id);
+
+    return hash;
+}
+
+static gboolean fdb_cache_key_equal(gconstpointer left, gconstpointer right) {
+    const struct fdb_cache_key *key_left = left;
+    const struct fdb_cache_key *key_right = right;
+
+    // Compare MAC addresses
+    if (memcmp(key_left->mac, key_right->mac, ETH_ALEN) != 0)
+        return false;
+
+    // Compare ifindex
+    if (key_left->ifindex != key_right->ifindex)
+        return false;
+
+    // Compare VLAN IDs
+    if (key_left->vlan_id != key_right->vlan_id)
+        return false;
+
+    return true;
+}
+
+struct fdb_cache *cache_get_fdb(struct netlink_neigh_cmd *neigh_cmd)
+{
+    struct fdb_cache *cache = NULL;
+    struct fdb_cache_key key = {
+        .ifindex = neigh_cmd->ifindex,
+        .vlan_id = neigh_cmd->vlan_id,
+    };
+    memcpy(key.mac, neigh_cmd->mac, ETH_ALEN);
+
+    cache = g_hash_table_lookup(db_fdb_cache, &key);
+    if (!cache)
+        goto out;
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.referenced) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto out;
+    }
+    cache->reference_count++;
+
+out:
+    return cache;
+}
+
+struct fdb_cache *cache_get_fdb_by_reply(struct neighbor_reply *neighbor_reply,
+                                         int ifindex)
+{
+    struct netlink_neigh_cmd neigh = {
+        .vlan_id = neighbor_reply->vlan_id,
+        .ifindex = ifindex,
+    };
+
+    memcpy(neigh.mac, neighbor_reply->mac, ETH_ALEN);
+
+    return cache_get_fdb(&neigh);
+}
+
+struct fdb_cache *cache_add_fdb(struct netlink_neigh_cmd *neigh_cmd)
+{
+    struct link_cache *link;
+    struct fdb_cache *cache = NULL;
+    struct fdb_cache_key *key;
+
+    key = g_new0(struct fdb_cache_key, 1);
+    if (!key) {
+        pr_err(errno, "g_new0");
+        goto err0;
+    }
+    memcpy(key->mac, neigh_cmd->mac, ETH_ALEN);
+    key->ifindex = neigh_cmd->ifindex;
+    key->vlan_id = neigh_cmd->vlan_id;
+
+    link = cache_get_link(neigh_cmd->ifindex);
+    if (!link) {
+        pr_err(0, "FDB cache: Lookup: NIC: %d > Not found\n",
+               neigh_cmd->ifindex);
+        goto err1;
+    }
+
+    cache = g_new0(struct fdb_cache, 1);
+    if (!cache) {
+        pr_err(errno, "g_new0");
+        goto err1;
+    }
+
+    memcpy(cache->mac, neigh_cmd->mac, ETH_ALEN);
+    cache->link = link;
+    cache->vlan_id = neigh_cmd->vlan_id;
+
+    mac_to_string(cache->mac_str, cache->mac, sizeof(cache->mac_str));
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.created) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto err2;
+    }
+    cache->times.referenced = cache->times.created;
+
+    g_hash_table_insert(db_fdb_cache, key, cache);
+
+    return cache;
+err2:
+    g_free(cache);
+err1:
+    g_free(key);
+err0:
+    return NULL;
+}
+
+int cache_del_fdb(struct netlink_neigh_cmd *neigh_cmd)
+{
+    int ret = -1;
+    struct fdb_cache *cache;
+    struct fdb_cache_key key;
+
+    memcpy(key.mac, neigh_cmd->mac, ETH_ALEN);
+    key.ifindex = neigh_cmd->ifindex;
+    key.vlan_id = neigh_cmd->vlan_id;
+
+    cache = g_hash_table_lookup(db_fdb_cache, &key);
+    if (!cache)
+        goto out;
+
+    g_hash_table_remove(db_fdb_cache, &key);
+    ret = 0;
+out:
+    return ret;
+}
+
+static guint neigh_cache_key_hash(gconstpointer key)
+{
+    const struct neigh_cache_key *k = key;
+    guint hash = 0;
+
+    // Hash the ifindex
+    hash = hash * 31 + g_int_hash(&k->ifindex);
+
+    // Hash the IP address
+    for (guint i = 0; i < sizeof(k->ip); i++)
+        hash = hash * 31 + k->ip.s6_addr[i];
+
+    return hash;
+}
+
+static gboolean neigh_cache_key_equal(gconstpointer left, gconstpointer right)
+{
+    const struct neigh_cache_key *key_left = left;
+    const struct neigh_cache_key *key_right = right;
+
+    // Compare ifindex
+    if (key_left->ifindex != key_right->ifindex)
+        return false;
+
+    // Compare IP addresses
+    if (memcmp(&key_left->ip, &key_right->ip, sizeof(key_left->ip)) != 0)
+        return false;
+
+    return true;
+}
+
+struct neigh_cache *cache_add_neigh(struct link_network_cache *link_network,
+                                    struct netlink_neigh_cmd *neigh_cmd)
+{
+    struct neigh_cache *cache;
+    struct neigh_cache_key *key;
+
+    key = g_new0(struct neigh_cache_key, 1);
+    if (!key) {
+        pr_err(errno, "g_new0");
+        goto err0;
+    }
+
+    key->ifindex = neigh_cmd->ifindex;
+    memcpy(&key->ip, &neigh_cmd->ip, sizeof(key->ip));
+
+    cache = g_new0(struct neigh_cache, 1);
+    if (!cache) {
+        pr_err(errno, "g_new0");
+        goto err1;
+    }
+
+    memcpy(cache->mac, neigh_cmd->mac, ETH_ALEN);
+    memcpy(&cache->ip, &neigh_cmd->ip, sizeof(cache->ip));
+    mac_to_string(cache->mac_str, cache->mac, sizeof(cache->mac_str));
+    format_ip_address(cache->ip_str, sizeof(cache->ip_str), &cache->ip);
+    cache->nud_state = neigh_cmd->nud_state;
+
+    cache->sending_link_network = link_network;
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.created) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto err2;
+    }
+    cache->times.referenced = cache->times.created;
+
+    g_hash_table_insert(db_neigh_cache, key, cache);
+
+    return cache;
+err2:
+    g_free(cache);
+err1:
+    g_free(key);
+err0:
+    return NULL;
+}
+
+struct neigh_cache *cache_get_neigh(struct netlink_neigh_cmd *neigh_cmd)
+{
+    struct neigh_cache *cache = NULL;
+    struct neigh_cache_key key;
+
+    key.ifindex = neigh_cmd->ifindex;
+    memcpy(&key.ip, &neigh_cmd->ip, sizeof(key.ip));
+
+    cache = g_hash_table_lookup(db_neigh_cache, &key);
+    if (!cache)
+        goto out;
+
+    if (clock_gettime(CLOCK_REALTIME, &cache->times.referenced) == -1) {
+        pr_err(errno, "clock_gettime");
+        goto out;
+    }
+    cache->reference_count++;
+
+out:
+    return cache;
+}
+
+struct neigh_cache *cache_get_neigh_by_reply(
+    struct neighbor_reply *neighbor_reply, int ifindex)
+{
+    struct netlink_neigh_cmd neigh = {
+        .ifindex = ifindex,
+    };
+    memcpy(neigh.mac, neighbor_reply->mac, ETH_ALEN);
+    memcpy(&neigh.ip, &neighbor_reply->ip, sizeof(neigh.ip));
+
+    return cache_get_neigh(&neigh);
+}
+
+int cache_neigh_update(struct netlink_neigh_cmd *neigh_cmd)
+{
+    int ret = 0;
+    struct neigh_cache *cache;
+    struct neigh_cache_key key;
+
+    key.ifindex = neigh_cmd->ifindex;
+    memcpy(&key.ip, &neigh_cmd->ip, sizeof(key.ip));
+
+    cache = g_hash_table_lookup(db_neigh_cache, &key);
+    if (!cache) {
+        ret = -ENOENT;
+        goto out;
+    }
+
+    // Update the MAC address
+    if (!is_same_mac(cache->mac, neigh_cmd->mac))
+        memcpy(cache->mac, neigh_cmd->mac, ETH_ALEN);
+
+    if (neigh_cmd->nud_state != cache->nud_state) {
+        cache->nud_state = neigh_cmd->nud_state;
+        if (clock_gettime(CLOCK_REALTIME, &cache->times.updated) == -1) {
+            pr_err(errno, "clock_gettime");
+            ret = -errno;
+            goto out;
+        }
+        cache->times.referenced = cache->times.updated;
+        cache->update_count++;
+    }
+
+out:
+    return ret;
+}
+
+void cache_del_neigh(struct neigh_cache *neigh)
+{
+    struct neigh_cache_key key;
+
+    key.ifindex = neigh->ifindex;
+    memcpy(&key.ip, &neigh->ip, sizeof(key.ip));
+
+    g_hash_table_remove(db_neigh_cache, &key);
+}
+
+// Cache setup and cleanup functions
+int setup_cache(void)
+{
+    db_lookup_vlan_networkid = g_hash_table_new_full(
+        vlan_networkid_cache_key_hash, vlan_networkid_cache_key_equal,
+        g_free, NULL);
+    if (!db_lookup_vlan_networkid) {
+        pr_err(errno, "g_hash_table_new");
+        goto err0;
+    }
+
+    db_lookup_addr = g_hash_table_new_full(addr_cache_key_hash,
+                                                addr_cache_key_equal,
+                                                g_free, NULL);
+    if (!db_lookup_addr) {
+        pr_err(errno, "g_hash_table_new");
+        goto err1;
+    }
+
+    db_lookup_addr_ifindex = g_hash_table_new_full(ifindex_addr_key_hash,
+                                                   ifindex_addr_key_equal,
+                                                   g_free, NULL);
+    if (!db_lookup_addr_ifindex) {
+        pr_err(errno, "g_hash_table_new");
+        goto err2;
+    }
+
+    db_link_cache = g_hash_table_new(g_int_hash, g_int_equal);
+    if (!db_link_cache) {
+        pr_err(errno, "g_hash_table_new");
+        goto err3;
+    }
+
+    db_network_cache = g_hash_table_new(g_int_hash, g_int_equal);
+    if (!db_network_cache) {
+        pr_err(errno, "g_hash_table_new");
+        goto err4;
+    }
+
+    db_fdb_cache = g_hash_table_new_full(fdb_cache_key_hash, fdb_cache_key_equal,
+                                    g_free, g_free);
+    if (!db_fdb_cache) {
+        pr_err(errno, "g_hash_table_new");
+        goto err5;
+    }
+
+    db_neigh_cache = g_hash_table_new_full(neigh_cache_key_hash, neigh_cache_key_equal,
+                                           g_free, g_free);
+    if (!db_neigh_cache) {
+        pr_err(errno, "g_hash_table_new");
+        goto err6;
+    }
+
+    return 0;
+err6:
+    g_hash_table_destroy(db_fdb_cache);
+err5:
+    g_hash_table_destroy(db_network_cache);
+err4:
+    g_hash_table_destroy(db_link_cache);
+err3:
+    g_hash_table_destroy(db_lookup_addr_ifindex);
+err2:
+    g_hash_table_destroy(db_lookup_addr);
+err1:
+    g_hash_table_destroy(db_lookup_vlan_networkid);
+err0:
+    return -errno;
+}
+
+void cleanup_cache(void)
+{
+    if (db_lookup_vlan_networkid)
+        g_hash_table_destroy(db_lookup_vlan_networkid);
+
+    if (db_lookup_addr)
+        g_hash_table_destroy(db_lookup_addr);
+
+    if (db_lookup_addr_ifindex)
+        g_hash_table_destroy(db_lookup_addr_ifindex);
+
+    if (db_link_cache) {
+        for (GList *iter = g_hash_table_get_values(db_link_cache);
+             iter; iter = g_list_next(iter)) {
+            cache_del_link(iter->data);
+            g_free(iter->data);
+        }
+        g_hash_table_destroy(db_link_cache);
+    }
+
+    if (db_network_cache)
+        g_hash_table_destroy(db_network_cache);
+
+    if (db_fdb_cache)
+        g_hash_table_destroy(db_fdb_cache);
+
+    if (db_neigh_cache)
+        g_hash_table_destroy(db_neigh_cache);
+}

--- a/include/json_writer.h
+++ b/include/json_writer.h
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause) */
+/*
+ * Simple streaming JSON writer
+ *
+ * This takes care of the annoying bits of JSON syntax like the commas
+ * after elements
+ *
+ * Authors:    Stephen Hemminger <stephen@networkplumber.org>
+ */
+
+/*
+ * This file was taken from the iproute2 project
+*/
+
+#ifndef _JSON_WRITER_H_
+#define _JSON_WRITER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Opaque class structure */
+typedef struct json_writer json_writer_t;
+
+/* Create a new JSON stream */
+json_writer_t *jsonw_new(FILE *f);
+/* End output to JSON stream */
+void jsonw_destroy(json_writer_t **self_p);
+
+/* Cause output to have pretty whitespace */
+void jsonw_pretty(json_writer_t *self, bool on);
+
+/* Add property name */
+void jsonw_name(json_writer_t *self, const char *name);
+
+/* Add value  */
+__attribute__((format(printf, 2, 3)))
+void jsonw_printf(json_writer_t *self, const char *fmt, ...);
+void jsonw_string(json_writer_t *self, const char *value);
+void jsonw_bool(json_writer_t *self, bool value);
+void jsonw_float(json_writer_t *self, double number);
+void jsonw_float_fmt(json_writer_t *self, const char *fmt, double num);
+void jsonw_uint(json_writer_t *self, unsigned int number);
+void jsonw_u64(json_writer_t *self, uint64_t number);
+void jsonw_xint(json_writer_t *self, uint64_t number);
+void jsonw_hhu(json_writer_t *self, unsigned char num);
+void jsonw_hu(json_writer_t *self, unsigned short number);
+void jsonw_int(json_writer_t *self, int number);
+void jsonw_s64(json_writer_t *self, int64_t number);
+void jsonw_null(json_writer_t *self);
+void jsonw_luint(json_writer_t *self, unsigned long num);
+void jsonw_lluint(json_writer_t *self, unsigned long long num);
+
+/* Useful Combinations of name and value */
+void jsonw_string_field(json_writer_t *self, const char *prop, const char *val);
+void jsonw_bool_field(json_writer_t *self, const char *prop, bool value);
+void jsonw_float_field(json_writer_t *self, const char *prop, double num);
+void jsonw_uint_field(json_writer_t *self, const char *prop, unsigned int num);
+void jsonw_u64_field(json_writer_t *self, const char *prop, uint64_t num);
+void jsonw_xint_field(json_writer_t *self, const char *prop, uint64_t num);
+void jsonw_hhu_field(json_writer_t *self, const char *prop, unsigned char num);
+void jsonw_hu_field(json_writer_t *self, const char *prop, unsigned short num);
+void jsonw_int_field(json_writer_t *self, const char *prop, int num);
+void jsonw_s64_field(json_writer_t *self, const char *prop, int64_t num);
+void jsonw_null_field(json_writer_t *self, const char *prop);
+void jsonw_luint_field(json_writer_t *self, const char *prop,
+            unsigned long num);
+void jsonw_lluint_field(json_writer_t *self, const char *prop,
+            unsigned long long num);
+
+/* Collections */
+void jsonw_start_object(json_writer_t *self);
+void jsonw_end_object(json_writer_t *self);
+
+void jsonw_start_array(json_writer_t *self);
+void jsonw_end_array(json_writer_t *self);
+
+/* Override default exception handling */
+typedef void (jsonw_err_handler_fn)(const char *);
+
+#endif /* _JSON_WRITER_H_ */

--- a/lib.c
+++ b/lib.c
@@ -1,15 +1,17 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
-/* SPDX-FileCopyrightText: 2024 1984 <1984@1984.is> */
-/* SPDX-FileCopyrightText: 2024 Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileCopyrightText: 2024 - 1984 <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 - Freyx Solutions <frey@freyx.com> */
 /* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
 /* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
 
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 #include <arpa/inet.h>
 
 #include "neighsnoopd.h"
 
+extern struct env env;
 
 void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size)
 {
@@ -21,12 +23,49 @@ void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size)
              mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 }
 
+bool is_zero_mac(const __u8 *mac)
+{
+    return mac[0] == 0 && mac[1] == 0 && mac[2] == 0 &&
+           mac[3] == 0 && mac[4] == 0 && mac[5] == 0;
+}
+
+bool is_same_mac(const __u8 *mac1, const __u8 *mac2)
+{
+    return mac1[0] == mac2[0] && mac1[1] == mac2[1] && mac1[2] == mac2[2] &&
+           mac1[3] == mac2[3] && mac1[4] == mac2[4] && mac1[5] == mac2[5];
+}
+
 void calculate_network_address(const struct in6_addr *ip,
                                const struct in6_addr *netmask,
                                struct in6_addr *network)
 {
     for (int i = 0; i < 16; i++)
         network->s6_addr[i] = ip->s6_addr[i] & netmask->s6_addr[i];
+}
+
+struct in6_addr calculate_network_using_cidr(const struct in6_addr *ip,
+                                               int cidr)
+{
+    struct in6_addr network = *ip;
+
+    // Treat the IPv6 address as two 64-bit chunks
+    uint32_t *addr_part = (uint32_t*)&network.s6_addr[0];
+
+    for (int i = 0; i < 4; i++) {
+        if (cidr >= 32) {
+            // If the CIDR prefix is >= 32, no modification needed
+            cidr -= 32;
+        } else if (cidr > 0) {
+            // Mask out the bits when its less than 32 bit
+            uint32_t mask = ~((1 << (32 - cidr)) - 1);
+            addr_part[i] = addr_part[i] & htonl(mask);
+            cidr = 0;
+        } else {
+            // Zero out the rest of the address
+            addr_part[i] = 0;
+        }
+    }
+    return network;
 }
 
 int compare_ipv6_addresses(const struct in6_addr *addr1,
@@ -44,6 +83,23 @@ int format_ip_address(char *buf, size_t size, const struct in6_addr *addr)
         return inet_ntop(AF_INET, &addr->s6_addr[12], buf, size) == 0;
     else
         return inet_ntop(AF_INET6, addr, buf, size) == 0;
+}
+
+int format_ip_address_cidr(char *buf, size_t size, const struct in6_addr *addr,
+                        int cidr)
+{
+    const char *ret;
+    if (IN6_IS_ADDR_V4MAPPED(addr)) {
+        ret = inet_ntop(AF_INET, &addr->s6_addr[12], buf, size);
+        if (!ret)
+            return -1;
+        return snprintf(buf + strlen(buf), size - strlen(buf), "/%d", cidr - 96);
+    } else {
+        ret = inet_ntop(AF_INET6, addr, buf, size);
+        if (!ret)
+            return -1;
+        return snprintf(buf + strlen(buf), size - strlen(buf), "/%d", cidr);
+    }
 }
 
 /*
@@ -65,4 +121,11 @@ int calculate_cidr(const struct in6_addr *addr) {
             cidr += __builtin_popcountl(addr->__in6_u.__u6_addr32[i]);
     }
     return cidr;
+}
+
+struct timespec get_time(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts;
 }

--- a/lib/json_writer.c
+++ b/lib/json_writer.c
@@ -1,0 +1,390 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause) */
+/*
+ * Simple streaming JSON writer
+ *
+ * This takes care of the annoying bits of JSON syntax like the commas
+ * after elements
+ *
+ * Authors:    Stephen Hemminger <stephen@networkplumber.org>
+ */
+
+/*
+ * This file was taken from the iproute2 project
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <assert.h>
+#include <malloc.h>
+#include <inttypes.h>
+#include <stdint.h>
+
+#include "json_writer.h"
+
+struct json_writer {
+    FILE        *out;    /* output file */
+    unsigned    depth;  /* nesting */
+    bool        pretty; /* optional whitepace */
+    char        sep;    /* either nul or comma */
+};
+
+/* indentation for pretty print */
+static void jsonw_indent(json_writer_t *self)
+{
+    unsigned i;
+    for (i = 0; i < self->depth; ++i)
+        fputs("    ", self->out);
+}
+
+/* end current line and indent if pretty printing */
+static void jsonw_eol(json_writer_t *self)
+{
+    if (!self->pretty)
+        return;
+
+    putc('\n', self->out);
+    jsonw_indent(self);
+}
+
+/* If current object is not empty print a comma */
+static void jsonw_eor(json_writer_t *self)
+{
+    if (self->sep != '\0')
+        putc(self->sep, self->out);
+    self->sep = ',';
+}
+
+
+/* Output JSON encoded string */
+/* Handles C escapes, does not do Unicode */
+static void jsonw_puts(json_writer_t *self, const char *str)
+{
+    putc('"', self->out);
+    for (; *str; ++str)
+        switch (*str) {
+        case '\t':
+            fputs("\\t", self->out);
+            break;
+        case '\n':
+            fputs("\\n", self->out);
+            break;
+        case '\r':
+            fputs("\\r", self->out);
+            break;
+        case '\f':
+            fputs("\\f", self->out);
+            break;
+        case '\b':
+            fputs("\\b", self->out);
+            break;
+        case '\\':
+            fputs("\\\\", self->out);
+            break;
+        case '"':
+            fputs("\\\"", self->out);
+            break;
+        default:
+            putc(*str, self->out);
+        }
+    putc('"', self->out);
+}
+
+/* Create a new JSON stream */
+json_writer_t *jsonw_new(FILE *f)
+{
+    json_writer_t *self = malloc(sizeof(*self));
+    if (self) {
+        self->out = f;
+        self->depth = 0;
+        self->pretty = false;
+        self->sep = '\0';
+    }
+    return self;
+}
+
+/* End output to JSON stream */
+void jsonw_destroy(json_writer_t **self_p)
+{
+    json_writer_t *self = *self_p;
+
+    assert(self->depth == 0);
+    fputs("\n", self->out);
+    fflush(self->out);
+    free(self);
+    *self_p = NULL;
+}
+
+void jsonw_pretty(json_writer_t *self, bool on)
+{
+    self->pretty = on;
+}
+
+/* Basic blocks */
+static void jsonw_begin(json_writer_t *self, int c)
+{
+    jsonw_eor(self);
+    putc(c, self->out);
+    ++self->depth;
+    self->sep = '\0';
+}
+
+static void jsonw_end(json_writer_t *self, int c)
+{
+    assert(self->depth > 0);
+
+    --self->depth;
+    if (self->sep != '\0')
+        jsonw_eol(self);
+    putc(c, self->out);
+    self->sep = ',';
+}
+
+
+/* Add a JSON property name */
+void jsonw_name(json_writer_t *self, const char *name)
+{
+    jsonw_eor(self);
+    jsonw_eol(self);
+    self->sep = '\0';
+    jsonw_puts(self, name);
+    putc(':', self->out);
+    if (self->pretty)
+        putc(' ', self->out);
+}
+
+__attribute__((format(printf, 2, 3)))
+void jsonw_printf(json_writer_t *self, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    jsonw_eor(self);
+    vfprintf(self->out, fmt, ap);
+    va_end(ap);
+}
+
+/* Collections */
+void jsonw_start_object(json_writer_t *self)
+{
+    jsonw_begin(self, '{');
+}
+
+void jsonw_end_object(json_writer_t *self)
+{
+    jsonw_end(self, '}');
+}
+
+void jsonw_start_array(json_writer_t *self)
+{
+    jsonw_begin(self, '[');
+    if (self->pretty)
+        putc(' ', self->out);
+}
+
+void jsonw_end_array(json_writer_t *self)
+{
+    if (self->pretty && self->sep)
+        putc(' ', self->out);
+    self->sep = '\0';
+    jsonw_end(self, ']');
+}
+
+/* JSON value types */
+void jsonw_string(json_writer_t *self, const char *value)
+{
+    jsonw_eor(self);
+    jsonw_puts(self, value);
+}
+
+void jsonw_bool(json_writer_t *self, bool val)
+{
+    jsonw_printf(self, "%s", val ? "true" : "false");
+}
+
+void jsonw_null(json_writer_t *self)
+{
+    jsonw_printf(self, "null");
+}
+
+void jsonw_float(json_writer_t *self, double num)
+{
+    jsonw_printf(self, "%g", num);
+}
+
+void jsonw_hhu(json_writer_t *self, unsigned char num)
+{
+    jsonw_printf(self, "%hhu", num);
+}
+
+void jsonw_hu(json_writer_t *self, unsigned short num)
+{
+    jsonw_printf(self, "%hu", num);
+}
+
+void jsonw_uint(json_writer_t *self, unsigned int num)
+{
+    jsonw_printf(self, "%u", num);
+}
+
+void jsonw_u64(json_writer_t *self, uint64_t num)
+{
+    jsonw_printf(self, "%"PRIu64, num);
+}
+
+void jsonw_xint(json_writer_t *self, uint64_t num)
+{
+    jsonw_printf(self, "%"PRIx64, num);
+}
+
+void jsonw_luint(json_writer_t *self, unsigned long num)
+{
+    jsonw_printf(self, "%lu", num);
+}
+
+void jsonw_lluint(json_writer_t *self, unsigned long long num)
+{
+    jsonw_printf(self, "%llu", num);
+}
+
+void jsonw_int(json_writer_t *self, int num)
+{
+    jsonw_printf(self, "%d", num);
+}
+
+void jsonw_s64(json_writer_t *self, int64_t num)
+{
+    jsonw_printf(self, "%"PRId64, num);
+}
+
+/* Basic name/value objects */
+void jsonw_string_field(json_writer_t *self, const char *prop, const char *val)
+{
+    jsonw_name(self, prop);
+    jsonw_string(self, val);
+}
+
+void jsonw_bool_field(json_writer_t *self, const char *prop, bool val)
+{
+    jsonw_name(self, prop);
+    jsonw_bool(self, val);
+}
+
+void jsonw_float_field(json_writer_t *self, const char *prop, double val)
+{
+    jsonw_name(self, prop);
+    jsonw_float(self, val);
+}
+
+void jsonw_uint_field(json_writer_t *self, const char *prop, unsigned int num)
+{
+    jsonw_name(self, prop);
+    jsonw_uint(self, num);
+}
+
+void jsonw_u64_field(json_writer_t *self, const char *prop, uint64_t num)
+{
+    jsonw_name(self, prop);
+    jsonw_u64(self, num);
+}
+
+void jsonw_xint_field(json_writer_t *self, const char *prop, uint64_t num)
+{
+    jsonw_name(self, prop);
+    jsonw_xint(self, num);
+}
+
+void jsonw_hhu_field(json_writer_t *self, const char *prop, unsigned char num)
+{
+    jsonw_name(self, prop);
+    jsonw_hhu(self, num);
+}
+
+void jsonw_hu_field(json_writer_t *self, const char *prop, unsigned short num)
+{
+    jsonw_name(self, prop);
+    jsonw_hu(self, num);
+}
+
+void jsonw_luint_field(json_writer_t *self,
+            const char *prop,
+            unsigned long num)
+{
+    jsonw_name(self, prop);
+    jsonw_luint(self, num);
+}
+
+void jsonw_lluint_field(json_writer_t *self,
+            const char *prop,
+            unsigned long long num)
+{
+    jsonw_name(self, prop);
+    jsonw_lluint(self, num);
+}
+
+void jsonw_int_field(json_writer_t *self, const char *prop, int num)
+{
+    jsonw_name(self, prop);
+    jsonw_int(self, num);
+}
+
+void jsonw_s64_field(json_writer_t *self, const char *prop, int64_t num)
+{
+    jsonw_name(self, prop);
+    jsonw_s64(self, num);
+}
+
+void jsonw_null_field(json_writer_t *self, const char *prop)
+{
+    jsonw_name(self, prop);
+    jsonw_null(self);
+}
+
+#ifdef TEST
+int main(int argc, char **argv)
+{
+    json_writer_t *wr = jsonw_new(stdout);
+
+    jsonw_start_object(wr);
+    jsonw_pretty(wr, true);
+    jsonw_name(wr, "Vyatta");
+    jsonw_start_object(wr);
+    jsonw_string_field(wr, "url", "http://vyatta.com");
+    jsonw_uint_field(wr, "downloads", 2000000ul);
+    jsonw_float_field(wr, "stock", 8.16);
+
+    jsonw_name(wr, "ARGV");
+    jsonw_start_array(wr);
+    while (--argc)
+        jsonw_string(wr, *++argv);
+    jsonw_end_array(wr);
+
+    jsonw_name(wr, "empty");
+    jsonw_start_array(wr);
+    jsonw_end_array(wr);
+
+    jsonw_name(wr, "NIL");
+    jsonw_start_object(wr);
+    jsonw_end_object(wr);
+
+    jsonw_null_field(wr, "my_null");
+
+    jsonw_name(wr, "special chars");
+    jsonw_start_array(wr);
+    jsonw_string_field(wr, "slash", "/");
+    jsonw_string_field(wr, "newline", "\n");
+    jsonw_string_field(wr, "tab", "\t");
+    jsonw_string_field(wr, "ff", "\f");
+    jsonw_string_field(wr, "quote", "\"");
+    jsonw_string_field(wr, "tick", "\'");
+    jsonw_string_field(wr, "backslash", "\\");
+    jsonw_end_array(wr);
+
+    jsonw_end_object(wr);
+
+    jsonw_end_object(wr);
+    jsonw_destroy(&wr);
+    return 0;
+}
+
+#endif

--- a/neighsnoop.c
+++ b/neighsnoop.c
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-FileCopyrightText: 2024 - 1984 Hosting Company <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 - Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
+/* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#define SOCKET_PATH "/run/neighsnoopd.sock"
+#define BUFFER_SIZE 4096
+
+int main(void) {
+    int client_fd;
+    int count;
+    struct sockaddr_un addr;
+    char buffer[BUFFER_SIZE];
+
+    // Create a UNIX domain socket
+    if ((client_fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+        perror("socket");
+        exit(EXIT_FAILURE);
+    }
+
+    // Set up the socket address
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SOCKET_PATH, sizeof(addr.sun_path) - 1);
+
+    // Connect to the server
+    if (connect(client_fd, (struct sockaddr*)&addr,
+                sizeof(struct sockaddr_un)) == -1) {
+        perror("connect");
+        exit(EXIT_FAILURE);
+    }
+
+    // Read the response from the server
+    memset(buffer, 0, BUFFER_SIZE);
+    while ((count = read(client_fd, buffer, BUFFER_SIZE)) > 0)
+        write(STDOUT_FILENO, buffer, count);
+
+    close(client_fd);
+    return 0;
+}

--- a/neighsnoopd.c
+++ b/neighsnoopd.c
@@ -4,6 +4,21 @@
 /* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
 /* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
 
+/**
+ * @file neighsnoopd.c
+ * @brief The primary file for decision-making and handling.
+ *
+ * This is the primary file for the neighsnoopd program and handles the core
+ * functionality and decision-making. The core part of the program is the epoll
+ * loop, which monitors all events such as POSIX signals, Netlink messages, the
+ * eBPF ring buffer for ARP/ND data extracted by the XDP/TC eBPF code, and
+ * client requests for statistics. The neighsnoopd program is designed to be
+ * single-threaded, relying on file descriptors to manage all the events it
+ * needs to handle.
+ *
+ * @see neighsnoopd.h for the main header data structures and functions.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -19,15 +34,27 @@
 #include <ifaddrs.h>
 #include <regex.h>
 #include <string.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+
+#include <arpa/inet.h>
 
 #include <linux/bpf.h>
+#include <linux/rtnetlink.h>
+#include <linux/ipv6.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
-#include <linux/if_ether.h>
+#include <net/ethernet.h>
+#include <net/if_arp.h>
 
-#include <libmnl/libmnl.h>
-#include <linux/rtnetlink.h>
+#include <netinet/if_ether.h>
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
 
 #include "neighsnoopd.h"
 
@@ -37,30 +64,6 @@
 #include "version.in.h"
 
 struct env env = {0};
-
-struct lookup_cache {
-    struct neighbor_reply *neighbor_reply;
-    __u8 mac_str[MAC_ADDR_STR_LEN];
-    __u32 ifindex;
-    char ifname[IFNAMSIZ];
-    __u32 link_ifindex;
-    char kind[128];
-    char ip_str[INET6_ADDRSTRLEN];
-    __u32 cidr;
-
-    // FDB
-    bool is_ext_learned;
-    bool is_macvlan;
-
-    // Debug information for debug mode only
-    struct {
-        char network_str[INET6_ADDRSTRLEN];
-    } debug;
-};
-
-static __u32 nlm_seq;
-struct mnl_socket *nl;
-__u32 mnl_portid;
 
 const char *argp_program_version = "neighsnoopd v0.9\n"
     "Build date: " __DATE__ " " __TIME__ "\n" \
@@ -79,523 +82,408 @@ static const struct argp_option opts[] = {
     { "count", 'c', "NUM", 0, "This option handles a fixed number of ARP or NA"
       "replies before terminating the program."
       "Use this for debugging purposes only", 0 },
-    { "filter", 'f', "REGEXP", 0,
+    { "deny-filter", 'f', "REGEXP", 0,
       "Filters out interfaces with a regular expression exclude from adding to"
-      "the neighbor cache. Example: -f '^br0|.*-v0^'", 0 },
-    { "macvlan", 'm', NULL, 0, "Disable filtering macvlan devices from being"
-      "added to the neighbor cache.", 0 },
+      "the neighbor cache. Example: -f '^br0|.*-v1$'", 0 },
+    { "disable_ipv6ll_filter", 'l', NULL, 0,
+      "Disable the default IPv6 link-local filter", 0},
     { "no-qfilter-present", 'q', NULL, 0, "Do not replace the present Qdisc"
       "filter if it is present on the Ingress device", 0 },
     { "verbose", 'v', NULL, 0, "Verbose debug output", 0 },
     { "xdp", 'x', NULL, 0, "Attach XDP instead of TC. This option only works"
       "on devices with a VLAN header on the packets available to XDP.", 0},
-    { "disable_ipv6ll_filter", 'l', NULL, 0,
-      "Disable the default IPv6 link-local filter", 0},
     { NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help", 0 },
     {},
 };
 
-static int add_neigh(struct lookup_cache *cache)
-{
-    int err = -1; // the default return value is an error
+static bool filter_deny_interfaces(char *ifname);
 
-    char buf[MNL_SOCKET_BUFFER_SIZE];
-    struct nlmsghdr *nlh;
-    struct ndmsg *ndm;
-    struct in6_addr *addr = &cache->neighbor_reply->ip;
-    int ret;
-
-    nlh = mnl_nlmsg_put_header(buf);
-    nlh->nlmsg_type = RTM_NEWNEIGH;
-    if (cache->neighbor_reply->in_family == AF_INET6)
-        nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE | NLM_F_ACK;
-    else
-        nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_ACK | NLM_F_EXCL;
-    nlh->nlmsg_seq = ++nlm_seq;
-
-    ndm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ndm));
-    ndm->ndm_family = cache->neighbor_reply->in_family;
-    ndm->ndm_state = NUD_REACHABLE;
-    ndm->ndm_ifindex = cache->ifindex;
-
-    // Add IP address
-    if (IN6_IS_ADDR_V4MAPPED(addr)) {
-        struct in_addr ipv4_addr;
-        memcpy(&ipv4_addr, &addr->s6_addr[12], sizeof(ipv4_addr));
-        mnl_attr_put(nlh, NDA_DST, sizeof(ipv4_addr), &ipv4_addr);
-    } else {
-        mnl_attr_put(nlh, NDA_DST, sizeof(*addr), addr);
-    }
-
-    // Add MAC address
-    mnl_attr_put(nlh, NDA_LLADDR, sizeof(cache->neighbor_reply->mac),
-                 cache->neighbor_reply->mac);
-
-    // Add VLAN information if needed
-    if (cache->neighbor_reply->vlan_id > 0)
-        mnl_attr_put(nlh, NDA_VLAN, sizeof(cache->neighbor_reply->vlan_id),
-                     &cache->neighbor_reply->vlan_id);
-
-    pr_debug("Requesting to add neighbor:\n");
-    pr_debug("- Interface %d: %s\n", cache->ifindex, cache->ifname);
-    pr_debug("- IP address: %s\n", cache->ip_str);
-    pr_debug("- MAC address: %s\n", cache->mac_str);
-
-    pr_nl("Sending netlink message\n");
-    pr_nl_nlmsg(nlh, nlm_seq);
-
-    // Send Netlink request update neigh table
-    if (mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
-        pr_err(errno, "mnl_socket_sendto");
-        goto out;
-    }
-
-    // Parse the response
-    ret = mnl_socket_recvfrom(nl, buf, sizeof(buf));
-    if (ret < 0) {
-        pr_err(errno, "mnl_socket_recvfrom");
-        goto out;
-    }
-
-    pr_nl("Received netlink message\n");
-    pr_nl_nlmsg((struct nlmsghdr *)buf, nlm_seq);
-
-    err = mnl_cb_run(buf, ret, nlm_seq, mnl_portid,
-                     NULL, NULL);
-    if (err < MNL_CB_STOP) {
-        if (errno == EEXIST) {
-            pr_debug("Neighbor already exists in the cache\n");
-            goto out;
-        }
-        pr_err(errno, "Failed to parse Netlink message");
-        goto out;
-    }
-
-    err = 0; // Success
-    pr_info("Added MAC: %s IP: %s/%d to FDB on interface: %s\n",
-            cache->mac_str, cache->ip_str, cache->cidr, cache->ifname);
-
-out:
-    return err;
-}
-
-static bool filter_interfaces(char *ifname)
-{
-    int ret;
-    if (!env.has_filter)
-        return false;
-
-    ret = regexec(&env.regex_filter, ifname, 0, NULL, 0);
-    if (ret)
-        return false;
-
-    pr_debug("Filtered interface %s using filter: '%s'\n", ifname,
-             env.regexp_filter_ifname);
-    return true;
-}
-
-static int netlink_recv(struct nlmsghdr *nlh, char *buf, size_t buf_size,
-                        mnl_cb_t parse_nlm_func,
-                        struct lookup_cache *cache)
-{
-    int ret;
-
-    pr_nl("sending netlink message\n");
-    pr_nl_nlmsg(nlh, nlm_seq);
-
-    // Send Netlink request to fetch FDB entries
-    if (mnl_socket_sendto(nl, nlh, nlh->nlmsg_len) < 0) {
-        pr_err(errno, "mnl_socket_sendto");
-        return false;
-    }
-
-    // Parse the response
-    while ((ret = mnl_socket_recvfrom(nl, buf, buf_size)) > 0) {
-        pr_nl("received netlink message\n");
-        pr_nl_nlmsg((struct nlmsghdr *)buf, nlm_seq);
-
-
-        ret = mnl_cb_run(buf, ret, nlm_seq, mnl_portid, parse_nlm_func,
-                         cache);
-
-        if (nlh->nlmsg_type == NLMSG_DONE)
-            break;
-
-        if (nlh->nlmsg_type == NLMSG_ERROR) {
-            struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
-            if (err->error != 0)
-                pr_err(err->error, "Netlink error");
-
-            break;
-        }
-
-        if (ret < MNL_CB_STOP) {
-            pr_err(errno, "Failed to parse Netlink message");
-            break;
-        }
-    }
-
-    return ret;
-}
-
-static int parse_nlm(const struct nlmsghdr *nlh, size_t nlm_len,
-                     mnl_attr_cb_t parse_nlm_attr_func,
-                     const struct nlattr **tb, void *data)
-{
-    mnl_attr_parse(nlh, nlm_len, parse_nlm_attr_func, tb);
-
-    if (nlh->nlmsg_type == NLMSG_ERROR) {
-        struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
-        if (err->error != 0)
-            pr_err(err->error, "Netlink error");
-        return MNL_CB_STOP;
-    }
-
-    if (nlh->nlmsg_type == NLMSG_DONE)
-        return MNL_CB_STOP;
-
-    return MNL_CB_OK;
-}
-
-// Extract information about an ifindex using Netlink
-static int getlink_parse_attr_cb(const struct nlattr *attr, void *data)
-{
-    const struct nlattr **tb = data;
-    int type = mnl_attr_get_type(attr);
-
-    /* skip unsupported attribute in user-space */
-    if (mnl_attr_type_valid(attr, IFLA_MAX) < 0)
-        return MNL_CB_OK;
-
-    switch(type) {
-        case IFLA_LINK:
-            if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
-                pr_err(errno, "mnl_attr_validate");
-                return MNL_CB_ERROR;
-            }
-            break;
-        case IFLA_LINKINFO:
-            if (mnl_attr_validate(attr, MNL_TYPE_NESTED) < 0) {
-                pr_err(errno, "mnl_attr_validate");
-                return MNL_CB_ERROR;
-            }
-    }
-    tb[type] = attr;
-    return MNL_CB_OK;
-}
-
-static int getlink_parse_nlm_cb(const struct nlmsghdr *nlh, void *data)
-{
-    struct ifinfomsg *ifm = mnl_nlmsg_get_payload(nlh);
-    struct lookup_cache *cache = data;
-    struct nlattr *tb[IFLA_MAX + 1] = {};
-
-    if (nlh->nlmsg_type != RTM_NEWLINK) {
-        pr_err(0, "Unexpected Netlink message type %d, expected %d",
-               nlh->nlmsg_type, RTM_NEWLINK);
-        return MNL_CB_STOP;
-    }
-
-    int ret = parse_nlm(nlh, sizeof(*ifm), getlink_parse_attr_cb,
-                  (const struct nlattr **) tb, tb);
-    if (ret < 0)
-        return ret;
-
-    // Add attributes to cache
-    if (tb[IFLA_LINK])
-        cache->link_ifindex = mnl_attr_get_u32(tb[IFLA_LINK]);
-
-    if (tb[IFLA_LINKINFO]) {
-        struct nlattr *link_attr;
-        mnl_attr_for_each_nested(link_attr, tb[IFLA_LINKINFO]) {
-            if (mnl_attr_get_type(link_attr) == IFLA_INFO_KIND) {
-
-                snprintf(cache->kind, sizeof(cache->kind), "%s",
-                         mnl_attr_get_str(link_attr));
-            }
-        }
-    }
-
-    if (strcmp(cache->kind, "macvlan") == 0)
-        cache->is_macvlan = true;
-
-    return MNL_CB_OK;
-}
-
-static bool probe_ifindex(struct lookup_cache *cache)
-{
-    char buf[MNL_SOCKET_BUFFER_SIZE];
-    struct nlmsghdr *nlh;
-    struct ifinfomsg *ifm;
-    int ret;
-
-    nlh = mnl_nlmsg_put_header(buf);
-    nlh->nlmsg_type = RTM_GETLINK;
-    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
-    nlh->nlmsg_seq = ++nlm_seq;
-
-    ifm = mnl_nlmsg_put_extra_header(nlh, sizeof(struct ifinfomsg));
-    ifm->ifi_family = AF_UNSPEC;
-    ifm->ifi_index = cache->ifindex;
-
-    ret = netlink_recv(nlh, buf, sizeof(buf), getlink_parse_nlm_cb, cache);
-
-    if (ret < 0) {
-        pr_err(errno, "Failed to lookup interface %s", cache->ifname);
-        return false;
-    }
-
-    pr_debug("Device %d is of type: %s\n", cache->ifindex, strlen(
-                 cache->kind) ? cache->kind : "unknown");
-    return true;
-}
-
-// Extract information from the FDB using Netlink
-static int getneigh_parse_attr_cb(const struct nlattr *attr, void *data)
-{
-    const struct nlattr **tb = data;
-    int type = mnl_attr_get_type(attr);
-
-    /* skip unsupported attribute in user-space */
-    if (mnl_attr_type_valid(attr, NDA_MAX) < 0)
-        return MNL_CB_OK;
-
-    switch(type) {
-    case NDA_DST:
-    case NDA_LLADDR:
-        if (mnl_attr_validate(attr, MNL_TYPE_BINARY) < 0) {
-            pr_err(errno, "mnl_attr_validate");
-            return MNL_CB_ERROR;
-        }
-        break;
-    }
-    tb[type] = attr;
-    return MNL_CB_OK;
-}
-
-static int getneigh_parse_nlm_cb(const struct nlmsghdr *nlh, void *data)
-{
-    struct lookup_cache *cache = data;
-    struct ndmsg *ndm = mnl_nlmsg_get_payload(nlh);
-    struct nlattr *tb[NDA_MAX + 1] = {};
-    const __u8 *fdb_mac = NULL;
-
-    if (nlh->nlmsg_type != RTM_NEWNEIGH) {
-        pr_err(0, "Unexpected Netlink message type %d, expected %d",
-               nlh->nlmsg_type, RTM_NEWNEIGH);
-        return MNL_CB_STOP;
-    }
-
-    if (parse_nlm(nlh, sizeof(*ndm), getneigh_parse_attr_cb,
-                  (const struct nlattr **) tb, cache) < 0)
-        return MNL_CB_STOP;
-
-    if (tb[NDA_LLADDR] == NULL)
-        return MNL_CB_OK;
-
-    fdb_mac = mnl_attr_get_payload(tb[NDA_LLADDR]);
-    if (memcmp(fdb_mac, cache->neighbor_reply->mac,
-               sizeof(cache->neighbor_reply->mac)) != 0)
-        return MNL_CB_OK;
-
-    // Add attributes to cache
-    if (ndm->ndm_flags & NTF_EXT_LEARNED)
-        cache->is_ext_learned = true;
-
-    return MNL_CB_OK;
-}
-
-static bool probe_fdb(struct lookup_cache *cache)
-{
-    // Query the FDB entries in AF_BRIDGE for the specified MAC address
-    char buf[MNL_SOCKET_BUFFER_SIZE];
-    struct nlmsghdr *nlh;
-    struct ndmsg *ndm;
-    int ret;
-
-    nlh = mnl_nlmsg_put_header(buf);
-    nlh->nlmsg_type = RTM_GETNEIGH;
-    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_DUMP;
-    nlh->nlmsg_seq = ++nlm_seq;
-
-    ndm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ndm));
-    ndm->ndm_family = AF_BRIDGE;
-
-    ret = netlink_recv(nlh, buf, sizeof(buf), getneigh_parse_nlm_cb, cache);
-
-    if (ret < 0) {
-        pr_err(errno, "Failed lookup FDB");
-        return false;
-    }
-
-    return true;
-}
-
-static bool find_ifindex_from_ip(struct lookup_cache *cache)
-{
-    struct ifaddrs *ifaddr, *ifa;
-    struct sockaddr_in6 *addr6, *netmask6;
-    struct sockaddr_in *addr4, *netmask4;
-    struct in6_addr addr, netmask;
-    struct in6_addr *given_ip = &cache->neighbor_reply->ip;
-    struct in6_addr given_ip_network, network;
-    const char* matching_ifname = NULL;
-    __u32 matching_ifindex;
-
-    if (getifaddrs(&ifaddr) == -1)
-        goto err1;
-
-    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-        struct lookup_cache getlink_cache = *cache;
-        if (ifa->ifa_addr == NULL || ifa->ifa_netmask == NULL)
-            continue;
-
-        // Map legacy IPv4 addresses to IPv6
-        if (ifa->ifa_addr->sa_family == AF_INET) {
-            // Handle IPv4 to IPv6 mapping
-            addr4 = (struct sockaddr_in *)ifa->ifa_addr;
-            netmask4 = (struct sockaddr_in *)ifa->ifa_netmask;
-            map_ipv4_to_ipv6(&addr, addr4->sin_addr.s_addr);
-            map_ipv4_to_ipv6(&netmask, netmask4->sin_addr.s_addr);
-        } else if (ifa->ifa_addr->sa_family == AF_INET6) {
-            // Handle IPv6 addresses
-            addr6 = (struct sockaddr_in6 *)ifa->ifa_addr;
-            netmask6 = (struct sockaddr_in6 *)ifa->ifa_netmask;
-            addr = addr6->sin6_addr;
-            netmask = netmask6->sin6_addr;
-        } else { // Ignore unknown address families
-            continue;
-        }
-
-        // Calculate the network address
-        calculate_network_address(&addr, &netmask, &network);
-        calculate_network_address(given_ip, &netmask, &given_ip_network);
-
-        // Compare the network addresses
-        if (!compare_ipv6_addresses(&network, &given_ip_network))
-            continue;
-
-        getlink_cache.ifindex = if_nametoindex(ifa->ifa_name);
-        if (!getlink_cache.ifindex) {
-            pr_err(errno, "if_nametoindex");
-            continue;
-        }
-
-        probe_ifindex(&getlink_cache);
-
-        if (getlink_cache.link_ifindex == 0)
-            continue;
-
-        if (getlink_cache.link_ifindex != env.ifidx_mon) {
-            pr_debug("Skipping interface %d because it isn't directly"
-                     "connected to %d\n", getlink_cache.link_ifindex,
-                     env.ifidx_mon);
-            continue;
-        }
-
-        matching_ifname = ifa->ifa_name;
-        *cache = getlink_cache;
-        break; // Found a matching interface
-    }
-
-    if (!matching_ifname) {
-        pr_debug("No interface found for IP: %s\n", cache->ip_str);
-        goto err2;
-    }
-
-    matching_ifindex = if_nametoindex(matching_ifname);
-    if (!matching_ifindex) {
-        pr_err(errno, "if_nametoindex");
-        goto err2;
-    }
-
-    memcpy(cache->ifname, matching_ifname, sizeof(cache->ifname));
-    cache->ifindex = matching_ifindex;
-
-    cache->cidr = calculate_cidr(&netmask);
-
-    if (env.debug) {
-        if (format_ip_address(cache->debug.network_str,
-                              sizeof(cache->debug.network_str), &network)) {
-            pr_err(errno, "format_ip_address");
-            goto err2;
-        }
-        pr_debug("Found IP: %s in %s/%d on %s linked to %s\n",
-                 cache->ip_str,
-                 cache->debug.network_str,
-                 cache->cidr,
-                 cache->ifname,
-                 env.ifidx_mon_str);
-    }
-    return true;
-err2:
-    freeifaddrs(ifaddr);
-err1:
-    return false;
-}
-
-// Callback function to handle data from the ring buffer
+// Callback function to handle data from the BPF ring buffer
 static int handle_neighbor_reply(void *ctx, void *data, size_t data_sz)
 {
-    struct lookup_cache cache = {0};
-    cache.neighbor_reply = (struct neighbor_reply *)data;
+    struct neighbor_reply *neighbor_reply = (struct neighbor_reply *)data;
+    struct link_network_cache *link_net;
+    struct link_cache *link;
+    struct fdb_cache *fdb;
+    __u8 mac_str[MAC_ADDR_STR_LEN];
+    char ip_str[INET6_ADDRSTRLEN];
 
-    if (env.only_ipv6 && cache.neighbor_reply->in_family != AF_INET6)
+    if (!neighbor_reply) {
+        pr_err(0, "Neighbor Reply: Invalid data");
         return 1;
-    else if (env.only_ipv4 && cache.neighbor_reply->in_family != AF_INET)
+    }
+
+    if (env.only_ipv6 && neighbor_reply->in_family != AF_INET6)
+        return 1;
+    else if (env.only_ipv4 && neighbor_reply->in_family != AF_INET)
         return 1;
 
     env.count--;
 
-    pr_debug("Received Neighbor Reply\n");
-
-    mac_to_string(cache.mac_str, cache.neighbor_reply->mac,
-                  sizeof(cache.mac_str));
-
-    if (format_ip_address(cache.ip_str, sizeof(cache.ip_str),
-                          &cache.neighbor_reply->ip)) {
-        pr_err(errno, "format_ip_address");
+    link_net = cache_get_link_network_by_reply(neighbor_reply);
+    if (!link_net) {
+        pr_err(0, "NIC with VLAN ID: %d Network: %d not found in cache",
+               neighbor_reply->vlan_id, neighbor_reply->network_id);
         return 1;
     }
+    link = link_net->link;
 
-    pr_debug("Received Neighbor Reply MAC: %s - IP: %s\n", cache.mac_str,
-             cache.ip_str);
+    fdb = cache_get_fdb_by_reply(neighbor_reply, link->ifindex);
+    if (fdb) {
+        pr_debug("Neighbor Reply: IP: %s MAC: %s nic: %s is externally learned. Skipping\n",
+                 fdb->mac_str, link_net->network->network_str, fdb->link->ifname);
+        return 0;
+    }
 
-    if (!env.disable_ipv6ll_filter &
-        (cache.neighbor_reply->in_family == AF_INET6)) {
-        if (IN6_IS_ADDR_LINKLOCAL(&cache.neighbor_reply->ip)) {
-            pr_debug("Neighbor IP '%s' is IPv6 link-local: filtered\n", cache.ip_str);
-            return 1;
+    mac_to_string(mac_str, neighbor_reply->mac, sizeof(mac_str));
+    format_ip_address(ip_str, sizeof(ip_str), &neighbor_reply->ip);
+    pr_debug("Neighbor Reply: IP: %s MAC: %s nic: %s\n",
+            ip_str, mac_str, link->ifname);
+
+    // Make the neighbor entry reachable in the Linux kernel's neighbor table
+    // This will also prompt a Netlink reply from the kernel that we will use to
+    // update our local cache
+    netlink_send_neigh(neighbor_reply, link->ifindex);
+
+    return 0;
+}
+
+static int handle_neigh_add(struct netlink_neigh_cmd *cmd)
+{
+    struct link_cache *link;
+    struct link_network_cache *link_net;
+    struct neigh_cache *neigh;
+
+    char ip_str[INET6_ADDRSTRLEN];
+    __u8 mac_str[MAC_ADDR_STR_LEN];
+
+    // Ignore neigh events until we are initialized
+    if (!(env.has_links && env.has_networks && env.has_fdb))
+        goto out;
+
+    if (env.debug) {
+        format_ip_address(ip_str, sizeof(ip_str), &cmd->ip);
+        mac_to_string(mac_str, cmd->mac, sizeof(mac_str));
+    }
+
+    // Skip entries without an interface
+    if (cmd->ifindex == 0) {
+        pr_debug("Neigh: IP: %s MAC: %s has no interface\n",
+                 ip_str, mac_str);
+        goto out;
+    }
+
+    // Skip incomplete entries
+    if (is_zero_mac(cmd->mac))
+        goto out;
+
+    // We skip externally learned entries
+    if (cmd->is_externally_learned) {
+        pr_debug("Neigh: IP: %s MAC: %s is externally learned\n",
+                 ip_str, mac_str);
+        goto out;
+    }
+
+    // Check if the link is a connected SVI
+    link = cache_get_link(cmd->ifindex);
+    if (!link) {
+        pr_err(0, "Failed to lookup interface %d", cmd->ifindex);
+        goto out;
+    }
+
+    // Ignoring IPs that are not part of a target network
+    link_net = cache_get_link_network_by_addr(link, &cmd->ip);
+    if (!link_net)
+        goto out;
+
+    neigh = cache_get_neigh(cmd);
+    if (neigh) { // Already cached
+        if (neigh->nud_state != cmd->nud_state)
+            cache_neigh_update(cmd);
+    } else { // Create a new cache entry
+        neigh = cache_add_neigh(link_net, cmd);
+        if (!neigh) {
+            pr_err(0, "Failed to add Neigh: IP: %s MAC: %s to cache\n",
+                   ip_str, mac_str);
+            goto out;
+        }
+        pr_info("Neigh: IP: %s MAC: %s nic: %s added to cache\n",
+                neigh->ip_str, neigh->mac_str,
+                link->ifname);
+    }
+
+out:
+    return 0;
+}
+
+static int handle_neigh_del(struct netlink_neigh_cmd *cmd)
+{
+    struct neigh_cache *neigh = cache_get_neigh(cmd);
+
+    if (!neigh) // Not cached
+        goto out;
+
+    cache_del_neigh(neigh);
+
+out:
+    return 0;
+}
+
+static int handle_fdb_add(struct netlink_neigh_cmd *cmd)
+{
+    int ret = 0;
+    struct link_cache *link;
+    struct fdb_cache *fdb;
+    __u8 mac_str[MAC_ADDR_STR_LEN];
+
+    // Ignore neigh events until we are initialized
+    if (!(env.has_links && env.has_networks))
+        goto out;
+
+    // Skip entries without an interface
+    if (cmd->ifindex == 0)
+        goto out;
+
+    link = cache_get_link(cmd->ifindex);
+    if (!link) {
+        pr_err(0, "Failed to lookup interface %d", cmd->ifindex);
+        goto out;
+    }
+
+    if (cmd->is_externally_learned) {
+        mac_to_string(mac_str, cmd->mac, sizeof(mac_str));
+        pr_debug("FDB: MAC: %s is externally learned: Not cached\n", mac_str);
+        goto out;
+    }
+
+    fdb = cache_get_fdb(cmd);
+    if (fdb) // Already cached
+        goto out;
+
+    fdb = cache_add_fdb(cmd);
+    if (!fdb) {
+        mac_to_string(mac_str, cmd->mac, sizeof(mac_str));
+        pr_err(0, "Failed to add FDB: MAC: %s to cache\n", mac_str);
+        ret = -1;
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static int handle_fdb_del(struct netlink_neigh_cmd *cmd)
+{
+    struct fdb_cache *fdb = cache_get_fdb(cmd);
+
+    if (!fdb) // Not cached
+        goto out;
+
+    cache_del_fdb(cmd);
+
+out:
+    return 0;
+}
+
+static int handle_addr_add(struct netlink_addr_cmd *cmd)
+{
+    int ret = 0;
+    struct network_cache *network;
+    struct link_cache *link;
+    struct link_network_cache *link_net;
+    char network_cidr_str[INET6_ADDRSTRLEN + 4]; // IPv6 address + / + prefixlen
+
+    // Ignore neigh events until we are initialized
+    if (!env.has_links)
+        goto out;
+
+    if (!env.disable_ipv6ll_filter) {
+        if (IN6_IS_ADDR_LINKLOCAL(&cmd->ip))
+            goto out;
+    }
+
+    link = cache_get_link(cmd->ifindex);
+    if (!link) {
+        pr_debug("Failed to lookup interface %d\n", cmd->ifindex);
+        goto out;
+    }
+
+    if (!link->is_svi) {
+        pr_debug("Link: %s is not an SVI connected to the bridge\n",
+                 link->ifname);
+        goto out;
+    }
+
+    format_ip_address_cidr(network_cidr_str, sizeof(network_cidr_str),
+                        &cmd->ip, cmd->prefixlen);
+
+    network = cache_get_network(cmd);
+    if (!network) {
+        network = cache_add_network(cmd);
+        if (!network) {
+            pr_err(0, "Failed to add network %s to cache", network_cidr_str);
+            ret = -1;
+            goto out;
         }
     }
 
-    if (!find_ifindex_from_ip(&cache)) {
-        pr_debug("No interface mached destination: filtered\n");
-        return 1;
+    link_net = cache_get_link_network(link->ifindex, network->network);
+    if (!link_net) {
+        link_net = cache_new_link_network();
+        if (!link_net) {
+            pr_err(0, "Failed to add link %s to network %s",
+                   link->ifname, network_cidr_str);
+            ret = -1;
+            goto out;
+        }
+
+        link_net->link = link;
+        link_net->network = network;
+        link_net->ip = calculate_network_using_cidr(&network->network,
+                                                    cmd->prefixlen);
+
+        ret = cache_add_link_network(link_net);
+        if (ret)
+            goto out;
+
+        pr_info("Cache: Added: Network(%d): %s with link %s\n",
+                network->id, network_cidr_str, link->ifname);
     }
 
-    if (filter_interfaces(cache.ifname)) {
-        pr_debug("Interface '%s' matches regexp filter: filtered\n",
-                 cache.ifname);
-        return 1;
+out:
+    return ret;
+}
+
+static int handle_addr_del(struct netlink_addr_cmd *cmd)
+{
+    int ret = -1;
+    struct network_cache *network = cache_get_network(cmd);
+
+    if (!network) {
+        pr_debug("Network: %s/%d not cached: Can't remove\n",
+                 network->network_str, network->prefixlen);
+        goto out;
     }
 
-    if (cache.is_macvlan && !env.disable_macvlan_filter) {
-        pr_debug("Interface '%s' is a macvlan: filtered\n", cache.ifname);
-        return 1;
+    cache_del_network(cmd);
+
+    pr_info("Cache: Removing Network: %s/%d\n", network->network_str,
+            network->prefixlen);
+
+    ret = 0;
+
+out:
+    return ret;
+}
+
+static int handle_link_add(struct netlink_link_cmd *cmd)
+{
+    int ret = 0;
+    struct link_cache *link;
+
+    link = cache_get_link(cmd->ifindex);
+    if (link) {
+        pr_debug("Link: %d: %s already cached\n",
+                 cmd->ifindex, cmd->ifname);
+        cache_update_link(link, cmd);
+        goto out;
+    } else {
+        link = cache_add_link(cmd);
+        if (!link) {
+            pr_err(errno, "Failed to add link %d: %s to cache",
+                   cmd->ifindex, cmd->ifname);
+            ret = -1;
+            goto out;
+        }
     }
 
-    probe_fdb(&cache);
-    if (cache.is_ext_learned) {
-        pr_debug("MAC address is not connected locally: filtered\n");
-        return 1;
+    link->is_svi = cmd->link_ifindex == env.ifidx_mon ? true : false;
+
+    if (filter_deny_interfaces(cmd->ifname)) {
+        pr_debug("Link: %d: %s matches regexp filter: filtered\n",
+                 cmd->ifindex, cmd->ifname);
+        link->ignore_link = true;
     }
 
-    pr_debug("MAC is locally connected. Adding neighbor.\n");
-    if (add_neigh(&cache))
-        return 1;
+    if (link->is_svi)
+        pr_info("Cache: Added: NIC: %s with vlan: %d\n",
+            cmd->ifname, cmd->vlan_id);
+    else
+        pr_debug("Cache: Added: NIC: %s with vlan: %d\n",
+            cmd->ifname, cmd->vlan_id);
 
-    // Success
+out:
+    return ret;
+}
+
+static int handle_link_del(struct netlink_link_cmd *cmd)
+{
+    int ret = 0;
+    struct link_cache *link = cache_get_link(cmd->ifindex);
+
+    if (!link) {
+        pr_debug("Cache: Link: %s not cached: Can't remove\n", cmd->ifname);
+        ret = -1;
+        goto out;
+    }
+
+    cache_del_link(cmd);
+
+    pr_info("Cache: Link: Removed: %s\n", cmd->ifname);
+
+out:
+    return ret;
+}
+
+static int handle_netlink_cmd(union netlink_cmd *cmd)
+{
+    int ret = 0;
+    switch (cmd->cmd_type) {
+        case CMD_NEIGH_ADD:
+            ret = handle_neigh_add(&cmd->neigh);
+            break;
+        case CMD_NEIGH_DEL:
+            ret = handle_neigh_del(&cmd->neigh);
+            break;
+        case CMD_FDB_ADD:
+            ret = handle_fdb_add(&cmd->neigh);
+            break;
+        case CMD_FDB_DEL:
+            ret = handle_fdb_del(&cmd->neigh);
+            break;
+        case CMD_ADDR_ADD:
+            ret = handle_addr_add(&cmd->addr);
+            break;
+        case CMD_ADDR_DEL:
+            ret = handle_addr_del(&cmd->addr);
+            break;
+        case CMD_LINK_ADD:
+            ret = handle_link_add(&cmd->link);
+            break;
+        case CMD_LINK_DEL:
+            ret = handle_link_del(&cmd->link);
+            break;
+        default:
+            pr_err(0, "Unknown command\n");
+            break;
+    }
+
+    netlink_cmd_free(cmd);
+
+    return ret;
+}
+
+static int handle_netlink(void)
+{
+    union netlink_cmd *cmd;
+
+    // Process all Netlink messages and prep the cmd queue
+    netlink_process_rx_queue();
+
+    while ((cmd = netlink_dequeue_cmd()))
+        if (handle_netlink_cmd(cmd))
+            return -1;
+
     return 0;
 }
 
@@ -620,14 +508,6 @@ out:
     return err;
 }
 
-static int handle_netlink(void)
-{
-    // TODO: Move all Netlink logic to this function
-    // This function will be responsible for monitoring all Netlink messages
-    // and update the eBPF code accordingly.
-    return 0;
-}
-
 static int handle_ring_buffer(void)
 {
     int err;
@@ -646,9 +526,24 @@ out:
 static void main_loop(void)
 {
     struct epoll_event events[env.number_of_fds];
+    bool last_round = false;
+
+    if (netlink_queue_send_next()) {
+        pr_err(errno, "Failed to send Netlink message");
+        return; // Failure
+    }
 
     while (true) {
-        int n = epoll_wait(env.epoll_fd, events, env.number_of_fds, -1);
+        int n;
+
+        if (env.has_count) {
+            if (last_round)
+                break;
+            if (env.count <= 0)
+                last_round = true;
+        }
+
+        n = epoll_wait(env.epoll_fd, events, env.number_of_fds, -1);
         if (n == -1) {
             if (errno == EINTR)
                 continue; // Ignore interrupted by signal
@@ -661,6 +556,7 @@ static void main_loop(void)
          * 1. Signal events
          * 2. Netlink events
          * 3. BPF ring buffer events
+         * 4. Send Netlink messages from the tx queue
          */
 
         // Signal events
@@ -682,11 +578,32 @@ static void main_loop(void)
         // BPF ring buffer events
         for (int i = 0; i < n; ++i) {
             if (events[i].data.fd == env.ringbuf_fd) {
-                if (handle_ring_buffer())
+                if (handle_ring_buffer()) {
+                    pr_err(errno, "Failed to consume ring buffer");
                     return; // Failure
+                }
             }
         }
+
+        // Send Netlink messages from the tx queue
+        if (netlink_queue_send_next()) {
+            pr_err(errno, "Failed to send Netlink message");
+            return; // Failure
+        }
     }
+}
+
+static bool filter_deny_interfaces(char *ifname)
+{
+    int ret;
+    if (!env.has_deny_filter)
+        return false;
+
+    ret = regexec(&env.deny_filter, ifname, 0, NULL, 0);
+    if (ret)
+        return false;
+
+    return true;
 }
 
 // Signal setup and cleanup
@@ -725,52 +642,9 @@ static void cleanup_signals(void)
         close(env.signal_fd);
 }
 
-// Netlink setup and cleanup
-static int setup_netlink(void)
-{
-    int err = 0;
-
-    nlm_seq = time(NULL);
-    if (err) {
-        fprintf(stderr, "Could not compile regex");
-        goto out;
-    }
-
-    nl = mnl_socket_open(NETLINK_ROUTE);
-    if (nl == NULL) {
-        err = errno;
-        perror("mnl_socket_open");
-        goto out;
-    }
-    mnl_portid = mnl_socket_get_portid(nl);
-    pr_nl("MNL port ID: %d\n", mnl_portid);
-
-    if (mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        err = -errno;
-        perror("mnl_socket_bind");
-        goto out;
-    }
-
-    env.nl_fd = mnl_socket_get_fd(nl);
-    if (env.nl_fd < 0) {
-        err = env.nl_fd;
-        perror("mnl_socket_get_fd");
-        goto out;
-    }
-    env.number_of_fds++;
-
-out:
-    return err;
-}
-
-static void cleanup_netlink(void)
-{
-    if (nl)
-        mnl_socket_close(nl);
-}
-
 // BPF setup and cleanup
-static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+                           va_list args)
 {
     if (level == LIBBPF_DEBUG && !env.debug)
         return 0;
@@ -792,12 +666,16 @@ static int setup_bpf(void)
         goto out;
     }
 
+    // Load the BPF program
     err = neighsnoopd_bpf__load(env.skel);
     if (err) {
         perror("Failed to load BPF skeleton\n");
         err = errno;
         goto out;
     }
+
+    env.target_networks_fd = bpf_map__fd(
+        bpf_object__find_map_by_name(env.skel->obj, "target_networks"));
 
     // XDP
     struct bpf_link *xdp_link;
@@ -897,7 +775,7 @@ static void cleanup_bpf(void)
 // epoll setup and cleanup
 static int setup_epoll(void)
 {
-    int err;
+    int err = 0;
     struct epoll_event event;
 
     env.epoll_fd = epoll_create1(0);
@@ -939,6 +817,43 @@ static void cleanup_epoll(void)
         close(env.epoll_fd);
 }
 
+static int setup_filters(void)
+{
+    int ret = 0;
+    if (env.has_deny_filter) {
+        ret = regcomp(&env.deny_filter, env.str_deny_filter, REG_EXTENDED);
+        if (ret) {
+            perror("Failed to compile regular expression");
+            goto out;
+        }
+    }
+
+out:
+    return ret;
+}
+
+static void cleanup_filters(void)
+{
+    if (env.has_deny_filter)
+        regfree(&env.deny_filter);
+}
+
+static int setup_packet(void)
+{
+    env.packet_fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (env.packet_fd == -1) {
+        perror("Failed to open packet socket");
+        return errno;
+    }
+    return 0;
+}
+
+static void cleanup_packet(void)
+{
+    if (env.packet_fd >= 0)
+        close(env.packet_fd);
+}
+
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
     static int pos_args;
@@ -978,11 +893,11 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
                 argp_usage(state);
                 exit(EXIT_FAILURE);
             }
-            env.regexp_filter_ifname = arg;
-            env.has_filter = true;
+            env.str_deny_filter = arg;
+            env.has_deny_filter = true;
             break;
-        case 'm':
-            env.disable_macvlan_filter = true;
+        case 'l':
+            env.disable_ipv6ll_filter = true;
             break;
         case 'q':
             env.fail_on_qfilter_present = true;
@@ -1046,47 +961,55 @@ int main(int argc, char **argv)
     err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
     if (err) {
         err = EXIT_FAILURE;
-        goto cleanup1;
+        goto cleanup0;
     }
 
-    if (env.has_filter) {
-        err = regcomp(&env.regex_filter, env.regexp_filter_ifname, REG_EXTENDED);
-        if (err) {
-            perror("Failed to compile regular expression");
-            err = EXIT_FAILURE;
-            goto cleanup1;
-        }
+    if (setup_filters()) {
+        err = EXIT_FAILURE;
+        goto cleanup0;
     }
-
-    if (setup_signals()) {
+    if (setup_packet()) {
         err = EXIT_FAILURE;
         goto cleanup1;
     }
-    if (setup_netlink()) {
+    if (setup_cache()) {
         err = EXIT_FAILURE;
         goto cleanup2;
     }
-    if (setup_bpf()) {
+    if (setup_signals()) {
         err = EXIT_FAILURE;
         goto cleanup3;
     }
-    if (setup_epoll()) {
+    if (setup_netlink()) {
         err = EXIT_FAILURE;
         goto cleanup4;
+    }
+    if (setup_bpf()) {
+        err = EXIT_FAILURE;
+        goto cleanup5;
+    }
+    if (setup_epoll()) {
+        err = EXIT_FAILURE;
+        goto cleanup6;
     }
 
     // Main loop
     main_loop();
 
     // Cleanup
-cleanup4:
     cleanup_epoll();
-cleanup3:
+cleanup6:
     cleanup_bpf();
-cleanup2:
+cleanup5:
     cleanup_netlink();
-cleanup1:
+cleanup4:
     cleanup_signals();
-
+cleanup3:
+    cleanup_cache();
+cleanup2:
+    cleanup_packet();
+cleanup1:
+    cleanup_filters();
+cleanup0:
     return err;
 }

--- a/neighsnoopd.c
+++ b/neighsnoopd.c
@@ -12,6 +12,8 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <signal.h>
+#include <sys/signalfd.h>
+#include <sys/epoll.h>
 #include <argp.h>
 #include <time.h>
 #include <ifaddrs.h>
@@ -55,8 +57,6 @@ struct lookup_cache {
         char network_str[INET6_ADDRSTRLEN];
     } debug;
 };
-
-static volatile sig_atomic_t exiting = 0;
 
 static __u32 nlm_seq;
 struct mnl_socket *nl;
@@ -599,16 +599,344 @@ static int handle_neighbor_reply(void *ctx, void *data, size_t data_sz)
     return 0;
 }
 
-static void sig_handler(int sig)
+static int handle_signal(void)
 {
-    exiting = true;
+    int err = 0;
+    struct signalfd_siginfo fdsi;
+    ssize_t s;
+
+    s = read(env.signal_fd, &fdsi, sizeof(struct signalfd_siginfo));
+    if (s != sizeof(struct signalfd_siginfo)) {
+        pr_err(errno, "read");
+        err = errno;
+        goto out;
+    }
+
+    if (fdsi.ssi_signo == SIGINT || fdsi.ssi_signo == SIGTERM) {
+        err = 1;
+    }
+
+out:
+    return err;
 }
 
+static int handle_netlink(void)
+{
+    // TODO: Move all Netlink logic to this function
+    // This function will be responsible for monitoring all Netlink messages
+    // and update the eBPF code accordingly.
+    return 0;
+}
+
+static int handle_ring_buffer(void)
+{
+    int err;
+
+    err = ring_buffer__consume(env.ringbuf);
+    if (err < 0) {
+        pr_err(err, "bpf_ringbuf_consume");
+        goto out;
+    }
+    err = 0; // The return value is the number of consumed records
+
+out:
+    return err;
+}
+
+static void main_loop(void)
+{
+    struct epoll_event events[env.number_of_fds];
+
+    while (true) {
+        int n = epoll_wait(env.epoll_fd, events, env.number_of_fds, -1);
+        if (n == -1) {
+            if (errno == EINTR)
+                continue; // Ignore interrupted by signal
+            pr_err(errno, "epoll_wait");
+            return; // Failure
+        }
+
+        /*
+         * We priorities the events from epoll as follows:
+         * 1. Signal events
+         * 2. Netlink events
+         * 3. BPF ring buffer events
+         */
+
+        // Signal events
+        for (int i = 0; i < n; ++i) {
+            if (events[i].data.fd == env.signal_fd) {
+                if (handle_signal())
+                    return; // Failure or exiting
+            }
+        }
+
+        // Netlink events
+        for (int i = 0; i < n; ++i) {
+            if (events[i].data.fd == env.nl_fd) {
+                if (handle_netlink())
+                    return; // Failure
+            }
+        }
+
+        // BPF ring buffer events
+        for (int i = 0; i < n; ++i) {
+            if (events[i].data.fd == env.ringbuf_fd) {
+                if (handle_ring_buffer())
+                    return; // Failure
+            }
+        }
+    }
+}
+
+// Signal setup and cleanup
+static int setup_signals(void)
+{
+    int err = 0;
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGINT);  // Handle SIGINT (Ctrl+C)
+    sigaddset(&mask, SIGTERM); // Handle SIGTERM
+
+    // Block these signals so they can be handled via signalfd
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1) {
+        perror("sigprocmask");
+        err = errno;
+        goto out;
+    }
+
+    // Create a signalfd to receive the signals
+    env.signal_fd = signalfd(-1, &mask, 0);
+    if (env.signal_fd == -1) {
+        perror("signalfd");
+        err = errno;
+        goto out;
+    }
+
+    env.number_of_fds++;
+
+out:
+    return err;
+}
+
+static void cleanup_signals(void)
+{
+    if (env.signal_fd >= 0)
+        close(env.signal_fd);
+}
+
+// Netlink setup and cleanup
+static int setup_netlink(void)
+{
+    int err = 0;
+
+    nlm_seq = time(NULL);
+    if (err) {
+        fprintf(stderr, "Could not compile regex");
+        goto out;
+    }
+
+    nl = mnl_socket_open(NETLINK_ROUTE);
+    if (nl == NULL) {
+        err = errno;
+        perror("mnl_socket_open");
+        goto out;
+    }
+    mnl_portid = mnl_socket_get_portid(nl);
+    pr_nl("MNL port ID: %d\n", mnl_portid);
+
+    if (mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
+        err = -errno;
+        perror("mnl_socket_bind");
+        goto out;
+    }
+
+    env.nl_fd = mnl_socket_get_fd(nl);
+    if (env.nl_fd < 0) {
+        err = env.nl_fd;
+        perror("mnl_socket_get_fd");
+        goto out;
+    }
+    env.number_of_fds++;
+
+out:
+    return err;
+}
+
+static void cleanup_netlink(void)
+{
+    if (nl)
+        mnl_socket_close(nl);
+}
+
+// BPF setup and cleanup
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
 {
     if (level == LIBBPF_DEBUG && !env.debug)
         return 0;
     return vfprintf(stderr, format, args);
+}
+
+static int setup_bpf(void)
+{
+    int err = 0;
+
+    libbpf_set_print(libbpf_print_fn);
+
+    // Open the skeleton
+    env.skel = neighsnoopd_bpf__open();
+    if (!env.skel) {
+        perror("Failed to open BPF skeleton\n");
+        err = errno;
+        env.skel = NULL;
+        goto out;
+    }
+
+    err = neighsnoopd_bpf__load(env.skel);
+    if (err) {
+        perror("Failed to load BPF skeleton\n");
+        err = errno;
+        goto out;
+    }
+
+    // XDP
+    struct bpf_link *xdp_link;
+
+    // TC OPTS
+    LIBBPF_OPTS(bpf_tc_hook, tc_hook,
+                .ifindex = env.ifidx_mon,
+                .attach_point = BPF_TC_INGRESS);
+    LIBBPF_OPTS(bpf_tc_opts, tc_opts,
+                .handle = 1,
+                .priority = 1,
+                .prog_fd = bpf_program__fd(
+                    env.skel->progs.handle_neighbor_reply_tc));
+
+    env.tc_opts = tc_opts;
+    env.tc_hook = tc_hook;
+
+    if (!env.fail_on_qfilter_present)
+        env.tc_opts.flags |= BPF_TC_F_REPLACE;
+
+    if (env.is_xdp) {
+        // attach xdp program to interface
+        xdp_link = bpf_program__attach_xdp(
+            env.skel->progs.handle_neighbor_reply_xdp, env.ifidx_mon);
+        if (!xdp_link) {
+            perror("Failed to attach XDP hook");
+            goto out;
+        }
+    } else {
+        // Load TC hook instead of XDP
+        // Attach the BPF program to the clsact qdisc for ingress
+
+        /*
+         * The TC Qdisc hook may already exist because:
+         * 1. Other processes or users create it.
+         * 2. By attaching to the TC ingress, the bpf_tc_hook_destroy does not
+         * remove the Qdisc and may leave an egress filter in place since the last
+         * invocation of the program.
+         */
+        err = bpf_tc_hook_create(&env.tc_hook);
+        if (err && err != -EEXIST) {
+            perror("Failed to create TC hook");
+            goto out;
+        }
+
+        if (bpf_tc_attach(&env.tc_hook, &env.tc_opts)) {
+            perror("Failed to attach TC hook");
+            goto out;
+        }
+    }
+    err = 0;
+
+    // Parse Neighbor replies
+    struct bpf_map *ringbuf_map =
+        bpf_object__find_map_by_name(env.skel->obj, "neighbor_ringbuf");
+
+    env.ringbuf = ring_buffer__new(bpf_map__fd(ringbuf_map),
+                                              handle_neighbor_reply, NULL, NULL);
+    if (!env.ringbuf) {
+        perror("Failed to create ring buffer");
+        err = errno;
+        goto out;
+    }
+
+    env.ringbuf_fd = bpf_map__fd(ringbuf_map);
+    if (env.ringbuf_fd < 0) {
+        perror("Failed to get ringbuf map fd");
+        err = env.ringbuf_fd;
+        goto out;
+    }
+
+out:
+    return err;
+}
+
+static void cleanup_bpf(void)
+{
+    int err;
+    if (env.ringbuf_fd >= 0)
+        close(env.ringbuf_fd);
+
+    env.tc_opts.flags = env.tc_opts.prog_fd = env.tc_opts.prog_id = 0;
+    if (!env.is_xdp) {
+        pr_debug("Detaching the TC hook\n");
+        err = bpf_tc_detach(&env.tc_hook, &env.tc_opts);
+        if (err)
+            perror("Failed to detach TC hook\n");
+    } else {
+        pr_debug("Destroying the TC hook\n");
+        err = bpf_tc_hook_destroy(&env.tc_hook);
+        if (err)
+            perror("Failed to destroy TC hook");
+    }
+    neighsnoopd_bpf__destroy(env.skel);
+}
+
+// epoll setup and cleanup
+static int setup_epoll(void)
+{
+    int err;
+    struct epoll_event event;
+
+    env.epoll_fd = epoll_create1(0);
+
+    // Add signalfd to epoll
+    event.events = EPOLLIN;
+    event.data.fd = env.signal_fd;
+    if (epoll_ctl(env.epoll_fd, EPOLL_CTL_ADD, env.signal_fd, &event) == -1) {
+        perror("epoll_ctl: signal_fd");
+        err = errno;
+        goto out;
+    }
+
+    // Add netlink socket to epoll
+    event.events = EPOLLIN;
+    event.data.fd = env.nl_fd;
+    if (epoll_ctl(env.epoll_fd, EPOLL_CTL_ADD, env.nl_fd, &event) == -1) {
+        perror("epoll_ctl: nl_fd");
+        err = errno;
+        goto out;
+    }
+
+    // Add BPF ring buffer to epoll
+    event.events = EPOLLIN;
+    event.data.fd = env.ringbuf_fd;
+    if (epoll_ctl(env.epoll_fd, EPOLL_CTL_ADD, env.ringbuf_fd, &event) == -1) {
+        perror("epoll_ctl: ringbuf_fd");
+        err = errno;
+        goto out;
+    }
+
+out:
+    return err;
+}
+
+static void cleanup_epoll(void)
+{
+    if (env.epoll_fd >= 0)
+        close(env.epoll_fd);
 }
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
@@ -706,8 +1034,8 @@ static void short_usage(FILE *fp, struct argp_state *state)
 
 int main(int argc, char **argv)
 {
-    struct neighsnoopd_bpf *skel;
     int err;
+
     static const struct argp argp = {
         .options = opts,
         .parser = parse_arg,
@@ -715,151 +1043,50 @@ int main(int argc, char **argv)
         .args_doc = "<IFNAME_MON>",
     };
 
-    nlm_seq = time(NULL);
-
     err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
-    if (err)
+    if (err) {
+        err = EXIT_FAILURE;
         goto cleanup1;
+    }
 
-    err = 0;
-    if (env.has_filter)
+    if (env.has_filter) {
         err = regcomp(&env.regex_filter, env.regexp_filter_ifname, REG_EXTENDED);
-
-    if (err) {
-        fprintf(stderr, "Could not compile regex");
-        goto cleanup1;
-    }
-
-    libbpf_set_print(libbpf_print_fn);
-
-    nl = mnl_socket_open(NETLINK_ROUTE);
-    if (nl == NULL) {
-        err = errno;
-        perror("mnl_socket_open");
-        goto cleanup1;
-    }
-    mnl_portid = mnl_socket_get_portid(nl);
-    pr_nl("MNL port ID: %d\n", mnl_portid);
-
-    if (mnl_socket_bind(nl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        err = -errno;
-        perror("mnl_socket_bind");
-        goto cleanup2;
-    }
-
-    // Open the skeleton
-    skel = neighsnoopd_bpf__open();
-    if (!skel) {
-        perror("Failed to open BPF skeleton\n");
-        err = EXIT_FAILURE;
-        goto cleanup2;
-    }
-
-    err = neighsnoopd_bpf__load(skel);
-    if (err) {
-        perror("Failed to load BPF skeleton\n");
-        err = EXIT_FAILURE;
-        goto cleanup2;
-    }
-
-    // XDP
-    struct bpf_link *xdp_link;
-
-    // TC OPTS
-    LIBBPF_OPTS(bpf_tc_hook, tc_hook,
-                .ifindex = env.ifidx_mon,
-                .attach_point = BPF_TC_INGRESS);
-    LIBBPF_OPTS(bpf_tc_opts, tc_opts,
-                .handle = 1,
-                .priority = 1,
-                .prog_fd = bpf_program__fd(
-                    skel->progs.handle_neighbor_reply_tc));
-
-    if (!env.fail_on_qfilter_present)
-        tc_opts.flags |= BPF_TC_F_REPLACE;
-
-    bool hook_created = false;
-    if (env.is_xdp) {
-        // attach xdp program to interface
-        xdp_link = bpf_program__attach_xdp(
-            skel->progs.handle_neighbor_reply_xdp, env.ifidx_mon);
-        if (!xdp_link) {
-            perror("Failed to attach XDP hook");
-            goto cleanup3;
+        if (err) {
+            perror("Failed to compile regular expression");
+            err = EXIT_FAILURE;
+            goto cleanup1;
         }
-    } else {
-        // Load TC hook instead of XDP
-        // Attach the BPF program to the clsact qdisc for ingress
-
-        /*
-         * The TC Qdisc hook may already exist because:
-         * 1. Other processes or users create it.
-         * 2. By attaching to the TC ingress, the bpf_tc_hook_destroy does not
-         * remove the Qdisc and may leave an egress filter in place since the last
-         * invocation of the program.
-         */
-        err = bpf_tc_hook_create(&tc_hook);
-        if (!err)
-            hook_created = true;
-        if (err && err != -EEXIST)
-            goto cleanup3;
-
-        if (bpf_tc_attach(&tc_hook, &tc_opts))
-            goto cleanup4;
     }
 
-    // Parse Neighbor replies
-    struct bpf_map *ringbuf_map =
-        bpf_object__find_map_by_name(skel->obj, "neighbor_ringbuf");
-
-    struct ring_buffer *rb = ring_buffer__new(bpf_map__fd(ringbuf_map),
-                                              handle_neighbor_reply, NULL, NULL);
-    if (!rb) {
-        fprintf(stderr, "Failed to create ring buffer");
-        goto cleanup5;
+    if (setup_signals()) {
+        err = EXIT_FAILURE;
+        goto cleanup1;
     }
-
-    if (signal(SIGINT, sig_handler) == SIG_ERR) {
-        err = errno;
-        perror("Can't set signal handler");
-        goto cleanup6;
+    if (setup_netlink()) {
+        err = EXIT_FAILURE;
+        goto cleanup2;
+    }
+    if (setup_bpf()) {
+        err = EXIT_FAILURE;
+        goto cleanup3;
+    }
+    if (setup_epoll()) {
+        err = EXIT_FAILURE;
+        goto cleanup4;
     }
 
     // Main loop
-    while (!exiting) {
-        int err = ring_buffer__poll(rb, -1);
-        if (err < 0) {
-            fprintf(stderr, "Error polling ring buffer");
-            break;
-        }
-        if (env.has_count && env.count == 0)
-            break;
-    }
-    err = 0;
+    main_loop();
 
     // Cleanup
-cleanup6:
-    ring_buffer__free(rb);
-    close(bpf_map__fd(ringbuf_map));
-cleanup5:
-    tc_opts.flags = tc_opts.prog_fd = tc_opts.prog_id = 0;
-    if (!env.is_xdp) {
-        pr_debug("Detaching the TC hook\n");
-        err = bpf_tc_detach(&tc_hook, &tc_opts);
-        if (err)
-            perror("Failed to detach TC hook\n");
-    }
 cleanup4:
-    if (hook_created) {
-        pr_debug("Destroying the TC hook\n");
-        err = bpf_tc_hook_destroy(&tc_hook);
-        if (err)
-            perror("Failed to destroy TC hook");
-    }
+    cleanup_epoll();
 cleanup3:
-    neighsnoopd_bpf__destroy(skel);
+    cleanup_bpf();
 cleanup2:
-    mnl_socket_close(nl);
+    cleanup_netlink();
 cleanup1:
-    return -err;
+    cleanup_signals();
+
+    return err;
 }

--- a/neighsnoopd.h
+++ b/neighsnoopd.h
@@ -13,7 +13,7 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <regex.h>
-
+#include <bpf/libbpf.h>
 #include <libmnl/libmnl.h>
 
 #define MAC_ADDR_STR_LEN 18
@@ -35,6 +35,20 @@ struct env {
     int count;
     bool netlink;
     bool disable_ipv6ll_filter;
+
+    // Event file descriptors
+    int signal_fd;
+    int nl_fd;
+    int ringbuf_fd;
+    int epoll_fd;
+    int number_of_fds;
+
+    struct ring_buffer *ringbuf;
+
+    // Setup and Cleanup states
+    struct neighsnoopd_bpf *skel;
+    struct bpf_tc_hook tc_hook;
+    struct bpf_tc_opts tc_opts;
 };
 
 void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size);

--- a/neighsnoopd.h
+++ b/neighsnoopd.h
@@ -9,23 +9,30 @@
 
 #include <stdio.h>
 #include <stdbool.h>
-#include <linux/types.h>
+#include <glib.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <linux/types.h>
+#include <linux/if_ether.h>
 #include <regex.h>
 #include <bpf/libbpf.h>
 #include <libmnl/libmnl.h>
 
+#include "neighsnoopd_shared.h"
+
 #define MAC_ADDR_STR_LEN 18
+
+#define STATS_SOCKET_PATH "/run/neighsnoopd.sock"
 
 struct env {
     int ifidx_mon;
     char ifidx_mon_str[IF_NAMESIZE];
-    char *regexp_filter_ifname;
-    regex_t regex_filter;
-    bool has_filter;
+    char *str_deny_filter;
+    regex_t allow_filter;
+    regex_t deny_filter;
+    bool has_allow_filter;
+    bool has_deny_filter;
     bool is_xdp;
-    bool disable_macvlan_filter;
     bool fail_on_qfilter_present;
     bool only_ipv4;
     bool only_ipv6;
@@ -43,23 +50,222 @@ struct env {
     int epoll_fd;
     int number_of_fds;
 
+    int packet_fd; // AF_PACKET socket
+
+    // BPF maps
     struct ring_buffer *ringbuf;
+    int target_networks_fd;
 
     // Setup and Cleanup states
     struct neighsnoopd_bpf *skel;
     struct bpf_tc_hook tc_hook;
     struct bpf_tc_opts tc_opts;
+
+    // Used in setup
+    bool has_links;
+    bool has_networks;
+    bool has_fdb;
+    __u32 link_seq; // Init sequence numbers
+    __u32 addr_seq;
+    __u32 fdb_seq;
+};
+
+struct nl_env {
+    __u32 mnl_portid;
+    struct mnl_socket *nl;
+    __u32 nlm_seq;
+
+    bool netlink_tx_in_progress;
+    GList *netlink_tx_queue;
+    int netlink_tx_queue_count;
+    int netlink_tx_count;
+
+    GList *netlink_cmd_queue;
+    int netlink_cmd_count;
+};
+
+enum cmd_type {
+    CMD_NONE,
+    CMD_LINK_ADD,
+    CMD_LINK_DEL,
+    CMD_ADDR_ADD,
+    CMD_ADDR_DEL,
+    CMD_FDB_ADD,
+    CMD_FDB_DEL,
+    CMD_NEIGH_ADD,
+    CMD_NEIGH_DEL
+};
+
+struct netlink_link_cmd {
+    enum cmd_type cmd_type;
+    char ifname[IF_NAMESIZE];
+    __u8 mac[ETH_ALEN];
+    char kind[128];
+    char slave_kind[128];
+    int ifindex;
+    __u32 vlan_protocol;
+    __u32 vlan_id;
+    bool has_vlan;
+    int link_ifindex;
+    bool is_macvlan;
+    bool is_vrf;
+};
+
+struct netlink_addr_cmd {
+    enum cmd_type cmd_type;
+    int ifindex;
+    struct in6_addr ip;
+    struct in6_addr network;
+    int prefixlen;
+    int true_prefixlen;
+    int flags;
+};
+
+struct netlink_neigh_cmd {
+    enum cmd_type cmd_type;
+    __u8 mac[ETH_ALEN];
+    int ifindex;
+    __u32 vlan_id;
+
+    int family;
+    int nud_state;
+    int type;
+    struct in6_addr ip;
+    bool is_externally_learned;
+    bool has_ip;
+};
+
+union netlink_cmd {
+    enum cmd_type cmd_type;
+    struct netlink_link_cmd link;
+    struct netlink_addr_cmd addr;
+    struct netlink_neigh_cmd neigh;
+};
+
+struct link_cache {
+    __u32 ifindex;
+    __u32 link_ifindex;
+    char ifname[IF_NAMESIZE];
+    __u8 mac[ETH_ALEN];
+    char kind[128];
+    char slave_kind[128];
+    __u32 vlan_protocol;
+    __u32 vlan_id;
+    bool has_vlan;
+    GList *network_list; // link_network_cache entries
+    GList *fdb_list;
+    GList *neigh_list;
+    bool is_svi;
+    bool is_macvlan;
+    bool ignore_link;
+
+    int reference_count;
+    struct {
+        struct timespec created;
+        struct timespec updated;
+        struct timespec referenced;
+    } times;
+};
+
+struct network_cache {
+    __u32 id;
+    struct in6_addr network;
+    char network_str[INET6_ADDRSTRLEN];
+    int prefixlen;
+    int true_prefixlen;
+    GList *links; // link_network_cache entries
+    int refcnt;
+
+    int reference_count;
+    struct {
+        struct timespec created;
+        struct timespec referenced;
+    } times;
+};
+
+struct link_network_cache {
+    struct in6_addr ip;
+    struct network_cache *network;
+    struct link_cache *link;
+};
+
+// Used to lookup network_link_cache
+struct vlan_networkid_cache_key {
+    __u32 network_id;
+    __u32 vlan_id;
+};
+
+// Used to lookup link_network_cache
+struct ifindex_addr_cache_key {
+    __u32 ifindex;
+    struct in6_addr network_ip;
+};
+
+struct fdb_cache_key {
+    __u8 mac[ETH_ALEN];
+    __u32 ifindex;
+    __u32 vlan_id;
+};
+
+// The fdb_cache is only used to check if an address is externally learned
+struct fdb_cache {
+    __u8 mac[ETH_ALEN];
+    __u8 mac_str[MAC_ADDR_STR_LEN];
+    struct link_cache *link;
+    __u32 vlan_id;
+
+    int reference_count;
+    struct {
+        struct timespec created;
+        struct timespec referenced;
+    } times;
+};
+
+struct neigh_cache_key {
+    __u32 ifindex;
+    struct in6_addr ip;
+};
+
+struct neigh_cache {
+    __u8 mac[ETH_ALEN];
+    __u8 mac_str[MAC_ADDR_STR_LEN];
+    __u32 ifindex; // Used for debugging
+    struct link_network_cache *sending_link_network;
+    int type;
+    struct in6_addr ip;
+    char ip_str[INET6_ADDRSTRLEN];
+    int nud_state;
+
+    int update_count;
+    int reference_count;
+    struct {
+        struct timespec created;
+        struct timespec updated;
+        struct timespec referenced;
+    } times;
+};
+
+enum cache_reference {
+    CACHE_NO_REFERENCE,
+    CACHE_REFERENCE,
 };
 
 void mac_to_string(__u8 *buffer, const __u8 *mac, size_t buffer_size);
+bool is_zero_mac(const __u8 *mac);
+bool is_same_mac(const __u8 *mac1, const __u8 *mac2);
 void calculate_network_address(const struct in6_addr *ip,
                                const struct in6_addr *netmask,
                                struct in6_addr *network);
+struct in6_addr calculate_network_using_cidr(const struct in6_addr *ip,
+                                               int cidr);
 int compare_ipv6_addresses(const struct in6_addr *addr1,
                            const struct in6_addr *addr2);
 int format_ip_address(char *buf, size_t size,
                              const struct in6_addr *addr);
+int format_ip_address_cidr(char *buf, size_t size, const struct in6_addr *addr,
+                        int cidr);
 int calculate_cidr(const struct in6_addr *addr);
+struct timespec get_time(void);
 
 // Print functions
 void __pr_std(FILE * file, const char *format, ...);
@@ -69,7 +275,66 @@ int pr_nl_attr_neigh(const struct nlattr *attr, void *data);
 int pr_nl_neigh_ndm(const struct nlmsghdr *nlh);
 int pr_nl_attr(const struct nlattr *attr, void *data);
 int pr_nl_ndm(const struct nlmsghdr *nlh);
-void pr_nl_nlmsg(struct nlmsghdr *nlh, __u32 seq);
+void pr_nl_nlmsg(struct nlmsghdr *nlh, size_t num_bytes);
+
+// Netlink functions
+int netlink_process_rx_queue(void);
+union netlink_cmd *netlink_dequeue_cmd(void);
+int netlink_parse_neigh_attr_cb(const struct nlattr *attr, void *data);
+int netlink_handle_neigh_cb(const struct nlmsghdr *nlh, void *data);
+int netlink_parse_addr_attr_cb(const struct nlattr *attr, void *data);
+int netlink_handle_addr_cb(const struct nlmsghdr *nlh, void *data);
+int netlink_parse_link_attr_cb(const struct nlattr *attr, void *data);
+int netlink_handle_link_cb(const struct nlmsghdr *nlh, void *data);
+int netlink_handle_all_cb(const struct nlmsghdr *nlh, void *data);
+int netlink_get_interfaces(void);
+int netlink_get_addresses(void);
+int netlink_get_fdb(void);
+int netlink_get_neighs(int family);
+int netlink_send_neigh(struct neighbor_reply *reply, int ifindex);
+int netlink_queue_add(struct nlmsghdr *nlh);
+struct nlmsghdr *netlink_queue_peek(void);
+struct nlmsghdr *netlink_queue_pop(void);
+int netlink_queue_send(struct nlmsghdr *nlh);
+int netlink_queue_send_next();
+void netlink_queue_check_ack_tx_queue(const struct nlmsghdr *nlh);
+void netlink_cmd_free(union netlink_cmd *cmd);
+int setup_netlink(void);
+void cleanup_netlink(void);
+
+// Cache functions
+struct link_cache *cache_add_link(struct netlink_link_cmd *link);
+int cache_update_link(struct link_cache *cache,
+                             struct netlink_link_cmd *link_cmd);
+int cache_add_link_network(struct link_network_cache *link_network);
+struct link_cache *cache_get_link(__u32 ifindex);
+int cache_del_link(struct netlink_link_cmd *link);
+struct link_network_cache *cache_new_link_network(void);
+struct link_network_cache *cache_get_link_network_by_reply(
+    struct neighbor_reply *neighbor_reply);
+struct link_network_cache *cache_get_link_network_by_addr(
+    struct link_cache *link, struct in6_addr *ip);
+struct link_network_cache *cache_get_link_network(int ifindex,
+                                                  struct in6_addr network_ip);
+struct network_cache *cache_add_network(struct netlink_addr_cmd *addr);
+struct network_cache *cache_get_network_by_id(__u32 network_id);
+struct network_cache *cache_get_network(struct netlink_addr_cmd *cmd);
+int cache_del_network(struct netlink_addr_cmd *addr);
+struct fdb_cache *cache_get_fdb(struct netlink_neigh_cmd *neigh);
+struct fdb_cache *cache_get_fdb_by_reply(struct neighbor_reply *neighbor_reply,
+                                         int ifindex);
+struct fdb_cache *cache_add_fdb(struct netlink_neigh_cmd *neigh);
+int cache_del_fdb(struct netlink_neigh_cmd *neigh);
+struct neigh_cache *cache_add_neigh(struct link_network_cache *link_network,
+                                    struct netlink_neigh_cmd *neigh_cmd);
+struct neigh_cache *cache_get_neigh(struct netlink_neigh_cmd *neigh);
+struct neigh_cache *cache_get_neigh_by_reply(struct neighbor_reply *neighbor_reply,
+                                             int ifindex);
+int cache_neigh_update(struct netlink_neigh_cmd *neigh);
+void cache_del_neigh(struct neigh_cache *neigh);
+int setup_cache(void);
+void cleanup_cache(void);
+
 
 // Prints info messages
 #define pr_info(fmt, ...)                              \
@@ -89,7 +354,8 @@ void pr_nl_nlmsg(struct nlmsghdr *nlh, __u32 seq);
 // Prints error messages with function and line number
 #define pr_err(err, fmt, ...)                                          \
     do {                                                               \
-        __pr_err(err, "ERROR: [%-10.10s:%d] " fmt, __func__, __LINE__, \
+        __pr_err(err, "ERROR: [%-13.13s: %-10.10s:%d] " fmt, __FILE__, \
+                 __func__, __LINE__,                                   \
                  ##__VA_ARGS__);                                       \
     } while (0)
 
@@ -103,9 +369,10 @@ void pr_nl_nlmsg(struct nlmsghdr *nlh, __u32 seq);
     } while (0)
 
 // Prints debug messages with function and line number
-#define pr_debug(fmt, ...)                                                          \
-    do {                                                                            \
-        __pr_debug("DEBUG: [%-10.10s:%d] " fmt, __func__, __LINE__, ##__VA_ARGS__); \
+#define pr_debug(fmt, ...)                                                    \
+    do {                                                                      \
+        __pr_debug("DEBUG: [%-13.13s: %-10.10s:%d] " fmt, __FILE__, __func__, \
+                   __LINE__, ##__VA_ARGS__);                                  \
     } while (0)
 
 // Prints netlink messages wihout prefix
@@ -118,10 +385,11 @@ void pr_nl_nlmsg(struct nlmsghdr *nlh, __u32 seq);
 
 
 // Prints netlink messages with function and line number
-#define pr_nl(fmt, ...)                                            \
-    do {                                                           \
-        __pr_nl("NETLINK: [%-10.10s:%d] " fmt, __func__, __LINE__, \
-                ##__VA_ARGS__);                                    \
+#define pr_nl(fmt, ...)                                                      \
+    do {                                                                     \
+        __pr_nl("NETLINK: [%-13.13s: %-10.10s:%d] " fmt, __FILE__, __func__, \
+                __LINE__,                                                    \
+                ##__VA_ARGS__);                                              \
     } while (0)
 
 #endif // NEIGHSNOOPD_H_

--- a/neighsnoopd.h
+++ b/neighsnoopd.h
@@ -48,6 +48,9 @@ struct env {
     int nl_fd;
     int ringbuf_fd;
     int epoll_fd;
+    int stats_server_fd;
+    int stats_client_fd;
+    int memfd_fd;
     int number_of_fds;
 
     int packet_fd; // AF_PACKET socket
@@ -334,6 +337,11 @@ int cache_neigh_update(struct netlink_neigh_cmd *neigh);
 void cache_del_neigh(struct neigh_cache *neigh);
 int setup_cache(void);
 void cleanup_cache(void);
+
+// stats functions
+int handle_stats_server_request(void);
+int setup_stats(void);
+void cleanup_stats(void);
 
 
 // Prints info messages

--- a/neighsnoopd_shared.h
+++ b/neighsnoopd_shared.h
@@ -7,22 +7,36 @@
 #ifndef NEIGHSNOOPD_SHARED_H_
 #define NEIGHSNOOPD_SHARED_H_
 
+struct network_entry {
+    __u32 prefixlen;
+    struct in6_addr network;
+};
+
+struct network_value {
+    __u32 network_id;
+};
+
 struct neighbor_reply {
-    __be16 vlan_id;
+    __u8 mac[6];
+    __be32 vlan_id;
+    __u32 network_id;
+
     struct in6_addr ip;
     __u8 in_family;
-    __u8 mac[6];
     __u32 ingress_ifindex;
 };
 
 /*
  * Maps an IPv4 address into an IPv6 address according to RFC 4291 sec 2.5.5.2
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 static void map_ipv4_to_ipv6(struct in6_addr *ipv6, __be32 ipv4)
 {
     __builtin_memset(((__u8 *)ipv6), 0x00, 10);
     __builtin_memset(((__u8 *)ipv6) + 10, 0xff, 2);
     ((__u32 *)ipv6)[3] = ipv4;
 }
+#pragma GCC diagnostic pop
 
 #endif // NEIGHSNOOPD_SHARED_H_

--- a/netlink.c
+++ b/netlink.c
@@ -1,0 +1,822 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-FileCopyrightText: 2024 - 1984 Hosting Company <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 - Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
+/* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
+
+#include "neighsnoopd.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <libmnl/libmnl.h>
+#include <linux/rtnetlink.h>
+#include <glib.h>
+#include <arpa/inet.h>
+
+extern struct env env;
+
+// Netlink environment
+struct nl_env nl_env = {
+    .netlink_tx_in_progress = false,
+    .netlink_tx_queue = NULL,
+    .netlink_tx_queue_count = 0,
+    .netlink_tx_count = 0,
+
+    .netlink_cmd_queue = NULL,
+    .netlink_cmd_count = 0,
+};
+
+int netlink_process_rx_queue(void)
+{
+    int ret;
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+
+    ret = mnl_socket_recvfrom(nl_env.nl, buf, sizeof(buf));
+    if (ret < 0) {
+        pr_err(errno, "mnl_socket_recvfrom");
+        return errno;
+    }
+
+    nlh = (struct nlmsghdr *)buf;
+
+    pr_nl("Received Netlink message: >>>>\n");
+    pr_nl_nlmsg(nlh, ret);
+    pr_nl("End of Received Netlink message: <<<<\n");
+
+    ret = mnl_cb_run(nlh, ret, nlh->nlmsg_seq, nl_env.mnl_portid,
+                     netlink_handle_all_cb, NULL);
+    if (ret < 0) {
+        pr_err(errno, "Failed to parse Netlink message");
+        return errno;
+    }
+
+    // Handle finished TX messages
+    if (nlh->nlmsg_type == NLMSG_DONE)
+        netlink_queue_check_ack_tx_queue(nlh);
+
+    if (nlh->nlmsg_type == NLMSG_ERROR) {
+        struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+
+        if (err->error != 0)
+            pr_err(err->error, "Netlink error");
+
+        netlink_queue_check_ack_tx_queue(&err->msg);
+    }
+
+    if (!env.has_links && env.link_seq == nlh->nlmsg_seq)
+        env.has_links = true;
+    if (!env.has_networks && env.addr_seq == nlh->nlmsg_seq)
+        env.has_networks = true;
+    if (!env.has_fdb && env.fdb_seq == nlh->nlmsg_seq)
+        env.has_fdb = true;
+
+    return 0;
+}
+
+bool netlink_queue_cmd(union netlink_cmd *cmd)
+{
+    union netlink_cmd *cmd_copy = calloc(1, sizeof(*cmd));
+    // Copy the right size of the command. This prevents flagging
+    // by memory sanitizers
+    switch (cmd->cmd_type) {
+        case CMD_FDB_ADD:
+        case CMD_FDB_DEL:
+            memcpy(&cmd_copy->neigh, &cmd->neigh, sizeof(cmd->neigh));
+            break;
+        case CMD_NEIGH_ADD:
+        case CMD_NEIGH_DEL:
+            memcpy(&cmd_copy->neigh, &cmd->neigh, sizeof(cmd->neigh));
+            break;
+        case CMD_ADDR_ADD:
+        case CMD_ADDR_DEL:
+            memcpy(&cmd_copy->addr, &cmd->addr, sizeof(cmd->addr));
+            break;
+        case CMD_LINK_ADD:
+        case CMD_LINK_DEL:
+            memcpy(&cmd_copy->link, &cmd->link, sizeof(cmd->link));
+            break;
+        case CMD_NONE:
+            break;
+    }
+
+    nl_env.netlink_cmd_queue = g_list_append(nl_env.netlink_cmd_queue, cmd_copy);
+    if (!nl_env.netlink_cmd_queue) {
+        pr_err(errno, "Failed to add Netlink command to queue");
+        return false;
+    }
+
+    return true;
+}
+
+union netlink_cmd *netlink_dequeue_cmd(void)
+{
+    union netlink_cmd *cmd;
+    if (nl_env.netlink_cmd_queue == NULL)
+        return NULL;
+
+    cmd = nl_env.netlink_cmd_queue->data;
+    nl_env.netlink_cmd_queue = g_list_delete_link(nl_env.netlink_cmd_queue,
+                                                  nl_env.netlink_cmd_queue);
+    return cmd;
+}
+
+int netlink_parse_neigh_attr_cb(const struct nlattr *attr, void *data)
+{
+    const struct nlattr **tb = data;
+    int type = mnl_attr_get_type(attr);
+
+    /* skip unsupported attribute in user-space */
+    if (mnl_attr_type_valid(attr, NDA_MAX) < 0)
+        return MNL_CB_OK;
+
+    switch(type) {
+        case NDA_DST:
+        case NDA_LLADDR:
+            if (mnl_attr_validate(attr, MNL_TYPE_BINARY) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case NDA_IFINDEX:
+            if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+    }
+
+    tb[type] = attr;
+    return MNL_CB_OK;
+}
+
+int netlink_handle_neigh_cb(const struct nlmsghdr *nlh, void *data)
+{
+    int type = nlh->nlmsg_type;
+    struct ndmsg *ndm = mnl_nlmsg_get_payload(nlh);
+    struct netlink_neigh_cmd neigh = {0};
+
+    struct nlattr *tb[NDA_MAX + 1] = {};
+
+    if (ndm->ndm_flags & NTF_ROUTER || ndm->ndm_flags & NTF_PROXY)
+        return MNL_CB_OK;
+
+    mnl_attr_parse(nlh, sizeof(struct ndmsg), netlink_parse_neigh_attr_cb, tb);
+
+    neigh.type = type;
+
+    if (tb[NDA_LLADDR]) {
+        memcpy(&neigh.mac, mnl_attr_get_payload(tb[NDA_LLADDR]),
+               sizeof(neigh.mac));
+        if (is_zero_mac(neigh.mac))
+            return MNL_CB_OK;
+    }
+
+    if (tb[NDA_DST]) {
+        if (ndm->ndm_family == AF_INET) {
+            struct in_addr ipv4_addr;
+            memcpy(&ipv4_addr, mnl_attr_get_payload(tb[NDA_DST]),
+                   sizeof(ipv4_addr));
+            map_ipv4_to_ipv6(&neigh.ip, ipv4_addr.s_addr);
+        } else {
+            memcpy(&neigh.ip, mnl_attr_get_payload(tb[NDA_DST]),
+                   sizeof(neigh.ip));
+        }
+        neigh.has_ip = true;
+    }
+
+    if (tb[NDA_IFINDEX])
+        neigh.ifindex = mnl_attr_get_u32(tb[NDA_IFINDEX]);
+    else
+        neigh.ifindex = ndm->ndm_ifindex;
+
+    if (ndm->ndm_flags & NTF_EXT_LEARNED)
+        neigh.is_externally_learned = true;
+
+    neigh.nud_state = ndm->ndm_state;
+
+    // Queue the FDB or Neighbor command
+    if (ndm->ndm_family == AF_BRIDGE) {
+        if (type == RTM_NEWNEIGH)
+            neigh.cmd_type = CMD_FDB_ADD;
+        else if (type == RTM_DELNEIGH)
+            neigh.cmd_type = CMD_FDB_DEL;
+        netlink_queue_cmd((union netlink_cmd *) &neigh);
+    } else if (ndm->ndm_family == AF_INET6 || ndm->ndm_family == AF_INET) {
+        if (type == RTM_NEWNEIGH)
+            neigh.cmd_type = CMD_NEIGH_ADD;
+        else if (type == RTM_DELNEIGH)
+            neigh.cmd_type = CMD_NEIGH_DEL;
+        netlink_queue_cmd((union netlink_cmd *) &neigh);
+    }
+
+    return MNL_CB_OK;
+}
+
+int netlink_parse_addr_attr_cb(const struct nlattr *attr, void *data)
+{
+    const struct nlattr **tb = data;
+    int type = mnl_attr_get_type(attr);
+
+    if (mnl_attr_type_valid(attr, IFA_MAX) < 0)
+        return MNL_CB_OK;
+
+    switch(type) {
+        case IFA_ADDRESS:
+            if (mnl_attr_validate(attr, MNL_TYPE_BINARY) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+    }
+
+    tb[type] = attr;
+    return MNL_CB_OK;
+}
+
+int netlink_handle_addr_cb(const struct nlmsghdr *nlh, void *data)
+{
+    int type = nlh->nlmsg_type;
+    struct netlink_addr_cmd addr = {0};
+    struct ifaddrmsg *ifa = mnl_nlmsg_get_payload(nlh);
+
+    struct nlattr *tb[IFA_MAX + 1] = {};
+
+    mnl_attr_parse(nlh, sizeof(*ifa), netlink_parse_addr_attr_cb, tb);
+
+    if (tb[IFA_ADDRESS] == NULL)
+        return MNL_CB_OK;
+
+    addr.ifindex = ifa->ifa_index;
+    addr.prefixlen = ifa->ifa_prefixlen;
+    addr.true_prefixlen = ifa->ifa_prefixlen;
+    addr.flags = ifa->ifa_flags;
+
+    // IPv4 and IPv6 addresses are stored in the same field
+    if (ifa->ifa_family == AF_INET) {
+        struct in_addr ipv4_addr;
+        memcpy(&ipv4_addr, mnl_attr_get_payload(tb[IFA_ADDRESS]),
+               sizeof(ipv4_addr));
+        map_ipv4_to_ipv6(&addr.ip, ipv4_addr.s_addr);
+        addr.prefixlen += 96;
+    } else {
+        memcpy(&addr.ip, mnl_attr_get_payload(tb[IFA_ADDRESS]),
+               sizeof(addr.ip));
+    }
+
+    addr.network = calculate_network_using_cidr(&addr.ip, addr.prefixlen);
+
+    // Queue the address command
+    if (type == RTM_NEWADDR)
+        addr.cmd_type = CMD_ADDR_ADD;
+    else if (type == RTM_DELADDR)
+        addr.cmd_type = CMD_ADDR_DEL;
+    netlink_queue_cmd((union netlink_cmd *) &addr);
+
+    return MNL_CB_OK;
+}
+
+int netlink_parse_link_infodata_attr_cb(const struct nlattr *attr, void *data)
+{
+    int type = mnl_attr_get_type(attr);
+    bool found = false;
+
+    if (mnl_attr_type_valid(attr, IFLA_INFO_MAX) < 0)
+        return MNL_CB_OK;
+
+    switch (type) {
+        case IFLA_VLAN_PROTOCOL:
+            if (mnl_attr_validate(attr, MNL_TYPE_U16))
+                found = true;
+            if (mnl_attr_validate(attr, MNL_TYPE_U32))
+                found = true;
+
+            if (!found) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case IFLA_VLAN_ID:
+            if (mnl_attr_validate(attr, MNL_TYPE_U16))
+                found = true;
+            if (mnl_attr_validate(attr, MNL_TYPE_U32))
+                found = true;
+
+            if (!found) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+    }
+
+    return MNL_CB_OK;
+}
+
+int netlink_parse_link_info_attr_cb(const struct nlattr *attr, void *data)
+{
+    int type = mnl_attr_get_type(attr);
+    struct nlattr *nested_attr = NULL;
+
+    if (mnl_attr_type_valid(attr, IFLA_INFO_MAX) < 0)
+        return MNL_CB_OK;
+
+    switch(type) {
+        case IFLA_INFO_KIND:
+            if (mnl_attr_validate(attr, MNL_TYPE_STRING) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case IFLA_INFO_SLAVE_KIND:
+            if (mnl_attr_validate(attr, MNL_TYPE_STRING) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+        case IFLA_INFO_DATA:
+            if (mnl_attr_validate(attr, MNL_TYPE_NESTED) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            mnl_attr_for_each_nested(nested_attr, attr) {
+                if (mnl_attr_validate(attr, MNL_TYPE_UNSPEC) < 0) {
+                    pr_err(errno, "mnl_attr_validate");
+                    return MNL_CB_ERROR;
+                }
+                if (netlink_parse_link_infodata_attr_cb(nested_attr, data) < 0)
+                    return MNL_CB_ERROR;
+            }
+    }
+
+    return MNL_CB_OK;
+}
+
+int netlink_parse_link_attr_cb(const struct nlattr *attr, void *data)
+{
+    const struct nlattr **tb = data;
+    int type = mnl_attr_get_type(attr);
+    struct nlattr *nested_attr = NULL;
+
+    /* skip unsupported attribute in user-space */
+    if (mnl_attr_type_valid(attr, IFLA_MAX) < 0)
+        return MNL_CB_OK;
+
+    switch(type) {
+        case IFLA_IFNAME:
+            if (mnl_attr_validate(attr, MNL_TYPE_STRING) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case IFLA_LINK:
+            if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case IFLA_ADDRESS:
+            if (mnl_attr_validate(attr, MNL_TYPE_BINARY) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            break;
+        case IFLA_LINKINFO:
+            if (mnl_attr_validate(attr, MNL_TYPE_NESTED) < 0) {
+                pr_err(errno, "mnl_attr_validate");
+                return MNL_CB_ERROR;
+            }
+            mnl_attr_for_each_nested(nested_attr, attr) {
+                if (netlink_parse_link_info_attr_cb(nested_attr, data) < 0)
+                    return MNL_CB_ERROR;
+            }
+    }
+    tb[type] = attr;
+    return MNL_CB_OK;
+}
+
+void netlink_handle_link_linkinfo(struct nlattr *tb[IFLA_MAX + 1],
+                                  struct netlink_link_cmd *link)
+{
+    struct nlattr *link_attr;
+    struct nlattr *nested_attr = NULL;
+
+    if (!tb[IFLA_LINKINFO])
+        return;
+
+    mnl_attr_for_each_nested(link_attr, tb[IFLA_LINKINFO]) {
+        if (mnl_attr_get_type(link_attr) == IFLA_INFO_KIND)
+            snprintf(link->kind, sizeof(link->kind), "%s",
+                     mnl_attr_get_str(link_attr));
+        else if (mnl_attr_get_type(link_attr) == IFLA_INFO_SLAVE_KIND)
+            snprintf(link->slave_kind, sizeof(link->slave_kind), "%s",
+                     mnl_attr_get_str(link_attr));
+        else if (mnl_attr_get_type(link_attr) == IFLA_INFO_DATA) {
+            mnl_attr_for_each_nested(nested_attr, link_attr) {
+                int nested_type = mnl_attr_get_type(nested_attr);
+
+                if (nested_type == IFLA_VLAN_PROTOCOL) {
+                    if (mnl_attr_validate(nested_attr, MNL_TYPE_U32))
+                        link->vlan_protocol = mnl_attr_get_u32(nested_attr);
+                    else
+                        link->vlan_protocol = mnl_attr_get_u16(nested_attr);
+                } else if (nested_type == IFLA_VLAN_ID) {
+                    if (mnl_attr_validate(nested_attr, MNL_TYPE_U32))
+                        link->vlan_id = mnl_attr_get_u32(nested_attr);
+                    else
+                        link->vlan_id = mnl_attr_get_u16(nested_attr);
+                }
+            }
+        }
+    }
+}
+
+int netlink_handle_link_cb(const struct nlmsghdr *nlh, void *data)
+{
+    int type = nlh->nlmsg_type;
+    int err;
+    struct netlink_link_cmd link = {0};
+    struct ifinfomsg *ifm = mnl_nlmsg_get_payload(nlh);
+
+    struct nlattr *tb[IFLA_MAX + 1] = {};
+
+    // Parse the Link message
+    err = mnl_attr_parse(nlh, sizeof(*ifm), netlink_parse_link_attr_cb, tb);
+    if (err < 0)
+        return MNL_CB_OK;
+
+    if (!tb[IFLA_IFNAME])
+        return MNL_CB_OK;
+
+    if (!tb[IFLA_ADDRESS])
+        return MNL_CB_OK;
+
+    snprintf(link.ifname, sizeof(link.ifname), "%s",
+             mnl_attr_get_str(tb[IFLA_IFNAME]));
+
+    memcpy(&link.mac, mnl_attr_get_payload(tb[IFLA_ADDRESS]), sizeof(link.mac));
+
+    link.ifindex = ifm->ifi_index;
+    if (tb[IFLA_LINK])
+        link.link_ifindex = mnl_attr_get_u32(tb[IFLA_LINK]);
+
+    netlink_handle_link_linkinfo(tb, &link);
+
+    if (strcmp(link.kind, "macvlan") == 0)
+        link.is_macvlan = true;
+
+    if (strcmp(link.slave_kind, "vrf") ==  0)
+        link.is_vrf = true;
+
+    if (link.vlan_protocol && link.vlan_id)
+        link.has_vlan = true;
+
+    // Queue the link command
+    if (type == RTM_NEWLINK)
+        link.cmd_type = CMD_LINK_ADD;
+    else if (type == RTM_DELLINK)
+        link.cmd_type = CMD_LINK_DEL;
+    netlink_queue_cmd((union netlink_cmd *) &link);
+
+    return MNL_CB_OK;
+}
+
+int netlink_handle_all_cb(const struct nlmsghdr *nlh, void *data)
+{
+    int ret;
+    if (nlh->nlmsg_type == RTM_NEWLINK || nlh->nlmsg_type == RTM_DELLINK)
+        ret = netlink_handle_link_cb(nlh, NULL);
+    else if (nlh->nlmsg_type == RTM_NEWADDR || nlh->nlmsg_type == RTM_DELADDR)
+        ret = netlink_handle_addr_cb(nlh, NULL);
+    else if (nlh->nlmsg_type == RTM_NEWNEIGH || nlh->nlmsg_type == RTM_DELNEIGH)
+        ret = netlink_handle_neigh_cb(nlh, NULL);
+    else
+        pr_debug("Received unknown Netlink message type %d\n",
+                 nlh->nlmsg_type);
+
+    nl_env.netlink_cmd_count++;
+
+    return ret;
+}
+
+// Netlink setup and cleanup
+int netlink_get_interfaces(void)
+{
+    int err = 0;
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+    struct ifinfomsg *ifm;
+
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_GETLINK;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_DUMP;
+    nlh->nlmsg_seq = ++nl_env.nlm_seq;
+    if (!env.has_links)
+        env.link_seq = nlh->nlmsg_seq;
+
+    ifm = mnl_nlmsg_put_extra_header(nlh, sizeof(struct ifinfomsg));
+    ifm->ifi_family = AF_UNSPEC;
+
+    if (netlink_queue_add(nlh)) {
+        pr_err(errno, "Failed to add Netlink message to tx queue");
+        err = -1;
+        goto out;
+    }
+
+out:
+    return err;
+}
+
+int netlink_get_addresses(void)
+{
+    int err = 0;
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+
+    struct nlmsghdr *nlh;
+    struct ifaddrmsg *ifa;
+
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_GETADDR;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_DUMP;
+    nlh->nlmsg_seq = ++nl_env.nlm_seq;
+    if (!env.has_networks)
+        env.addr_seq = nlh->nlmsg_seq;
+
+    ifa = mnl_nlmsg_put_extra_header(nlh, sizeof(struct ifaddrmsg));
+    ifa->ifa_family = AF_UNSPEC;
+
+    if (netlink_queue_add(nlh)) {
+        pr_err(errno, "Failed to add Netlink message to tx queue");
+        err = -1;
+        goto out;
+    }
+
+out:
+    return err;
+}
+
+int netlink_get_fdb(void)
+{
+    int err = 0;
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+    struct ndmsg *ndm;
+
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_GETNEIGH;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_DUMP;
+    nlh->nlmsg_seq = ++nl_env.nlm_seq;
+    if (!env.has_fdb)
+        env.fdb_seq = nlh->nlmsg_seq;
+
+    ndm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ndm));
+    ndm->ndm_family = AF_BRIDGE;
+    ndm->ndm_ifindex = env.ifidx_mon;
+
+    if (netlink_queue_add(nlh)) {
+        pr_err(errno, "Failed to add Netlink message to tx queue");
+        err = -1;
+    }
+
+    return err;
+}
+
+int netlink_get_neighs(int family)
+{
+    int err = 0;
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+    struct ndmsg *ndm;
+
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_GETNEIGH;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_DUMP;
+    nlh->nlmsg_seq = ++nl_env.nlm_seq;
+
+    ndm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ndm));
+    ndm->ndm_family = family;
+
+    if (netlink_queue_add(nlh)) {
+        pr_err(errno, "Failed to add Netlink message to tx queue");
+        err = -1;
+    }
+
+    return err;
+}
+
+int netlink_send_neigh(struct neighbor_reply *reply, int ifindex)
+{
+    char buf[MNL_SOCKET_BUFFER_SIZE];
+    struct nlmsghdr *nlh;
+    struct ndmsg *ndm;
+    struct in6_addr *addr = &reply->ip;
+    int ret;
+
+    nlh = mnl_nlmsg_put_header(buf);
+    nlh->nlmsg_type = RTM_NEWNEIGH;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE | NLM_F_ACK;
+    nlh->nlmsg_seq = ++nl_env.nlm_seq;
+
+    ndm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ndm));
+    ndm->ndm_type = RTN_UNICAST;
+    ndm->ndm_family = reply->in_family;
+    ndm->ndm_state = NUD_REACHABLE;
+    ndm->ndm_ifindex = ifindex;
+
+    // Add IP address
+    if (IN6_IS_ADDR_V4MAPPED(addr)) {
+        struct in_addr ipv4_addr;
+        memcpy(&ipv4_addr, &addr->s6_addr[12], sizeof(ipv4_addr));
+        mnl_attr_put(nlh, NDA_DST, sizeof(ipv4_addr), &ipv4_addr);
+    } else {
+        mnl_attr_put(nlh, NDA_DST, sizeof(*addr), addr);
+    }
+
+    // Add MAC address
+    mnl_attr_put(nlh, NDA_LLADDR, sizeof(reply->mac), reply->mac);
+
+    ret = mnl_socket_sendto(nl_env.nl, nlh, nlh->nlmsg_len);
+    if (ret < 0)
+        pr_err(errno, "mnl_socket_sendto");
+
+    return ret;
+}
+
+int netlink_queue_add(struct nlmsghdr *nlh)
+{
+    struct nlmsghdr *nlh_copy = malloc(nlh->nlmsg_len);
+    if (!nlh_copy) {
+        pr_err(errno, "malloc");
+        return errno;
+    }
+
+    memcpy(nlh_copy, nlh, nlh->nlmsg_len);
+    nl_env.netlink_tx_queue = g_list_append(nl_env.netlink_tx_queue, nlh_copy);
+
+    nl_env.netlink_tx_queue_count++;
+
+    return 0;
+}
+
+struct nlmsghdr *netlink_queue_peek(void)
+{
+    if (!nl_env.netlink_tx_queue)
+        return NULL;
+
+    return nl_env.netlink_tx_queue->data;
+}
+
+struct nlmsghdr *netlink_queue_pop(void)
+{
+    struct nlmsghdr *nlh = nl_env.netlink_tx_queue->data;
+    nl_env.netlink_tx_queue = g_list_delete_link(nl_env.netlink_tx_queue,
+                                                 nl_env.netlink_tx_queue);
+
+    nl_env.netlink_tx_queue_count--;
+    return nlh;
+}
+
+int netlink_queue_send(struct nlmsghdr *nlh)
+{
+    int ret;
+
+    pr_nl_nlmsg(nlh, nlh->nlmsg_len);
+
+    ret = mnl_socket_sendto(nl_env.nl, nlh, nlh->nlmsg_len);
+    if (ret < 0) {
+        pr_err(errno, "mnl_socket_sendto");
+        return errno;
+    }
+
+    nl_env.netlink_tx_in_progress = true;
+    nl_env.netlink_tx_count++;
+
+    return 0;
+}
+
+int netlink_queue_send_next()
+{
+    struct nlmsghdr *nlh;
+    int ret = 0;
+
+    if (!nl_env.netlink_tx_queue)
+        goto out;
+
+    if (nl_env.netlink_tx_in_progress)
+        goto out;
+
+    nlh = netlink_queue_peek();
+    ret = netlink_queue_send(nlh);
+
+out:
+    return ret;
+}
+
+void netlink_queue_check_ack_tx_queue(const struct nlmsghdr *nlh)
+{
+    struct nlmsghdr *head_of_queue;
+
+    if (!nl_env.netlink_tx_in_progress)
+        return;
+
+    head_of_queue = netlink_queue_peek();
+    if (head_of_queue) {
+        if (nlh->nlmsg_seq != head_of_queue->nlmsg_seq)
+            return;
+    }
+
+    netlink_queue_pop();
+    pr_nl("Netlink message %d processed\n", nlh->nlmsg_seq);
+
+    if (nlh->nlmsg_type == NLMSG_ERROR) {
+        struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+        if (err->error != 0)
+            pr_err(err->error, "Netlink error");
+    }
+
+    free(head_of_queue);
+    nl_env.netlink_tx_in_progress = false;
+}
+
+void netlink_cmd_free(union netlink_cmd *cmd)
+{
+    free(cmd);
+}
+
+int setup_netlink(void)
+{
+    int err = 0;
+    int size = 512 * 1024; // 512KB
+
+    nl_env.nlm_seq = time(NULL);
+    if (err) {
+        fprintf(stderr, "Could not compile regex");
+        goto out;
+    }
+
+    nl_env.nl = mnl_socket_open(NETLINK_ROUTE);
+    if (nl_env.nl == NULL) {
+        err = errno;
+        perror("mnl_socket_open");
+        goto out;
+    }
+    nl_env.mnl_portid = mnl_socket_get_portid(nl_env.nl);
+    pr_nl("MNL port ID: %d\n", nl_env.mnl_portid);
+
+    // Monitor for IPv4 and IPv6 network changes, link changes and
+    // neighbor changes
+    if (mnl_socket_bind(nl_env.nl, RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR |
+                        RTMGRP_LINK | RTMGRP_NEIGH,
+                        MNL_SOCKET_AUTOPID) < 0) {
+        err = -errno;
+        perror("mnl_socket_bind");
+        goto out;
+    }
+
+    env.nl_fd = mnl_socket_get_fd(nl_env.nl);
+    if (env.nl_fd < 0) {
+        err = env.nl_fd;
+        perror("mnl_socket_get_fd");
+        goto out;
+    }
+    env.number_of_fds++;
+
+    setsockopt(env.nl_fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
+
+    err = netlink_get_interfaces();
+    if (err) {
+        perror("Failed to get interfaces");
+        goto out;
+    }
+
+    err = netlink_get_addresses();
+    if (err) {
+        perror("Failed to get addresses");
+        goto out;
+    }
+
+    err = netlink_get_fdb();
+    if (err) {
+        perror("Failed to get FDB entries");
+        goto out;
+    }
+
+    err = netlink_get_neighs(AF_INET6);
+    if (err) {
+        perror("Failed to get IPv6 neighbors");
+        goto out;
+    }
+
+    err = netlink_get_neighs(AF_INET);
+    if (err) {
+        perror("Failed to get IPv4 neighbors");
+        goto out;
+    }
+
+out:
+    return err;
+}
+
+void cleanup_netlink(void)
+{
+    if (nl_env.nl)
+        mnl_socket_close(nl_env.nl);
+}

--- a/stats.c
+++ b/stats.c
@@ -1,0 +1,488 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-FileCopyrightText: 2024 - 1984 Hosting Company <1984@1984.is> */
+/* SPDX-FileCopyrightText: 2024 - Freyx Solutions <frey@freyx.com> */
+/* SPDX-FileContributor: Freysteinn Alfredsson <freysteinn@freysteinn.com> */
+/* SPDX-FileContributor: Julius Thor Bess Rikardsson <juliusbess@gmail.com> */
+
+#include <stdio.h>
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/mman.h>
+#include <linux/neighbour.h>
+
+#include "json_writer.h"
+#include "neighsnoopd.h"
+
+extern struct env env;
+extern GHashTable *db_link_cache;
+extern GHashTable *db_network_cache;
+extern GHashTable *db_fdb_cache;
+extern GHashTable *db_neigh_cache;
+
+extern GHashTable *db_lookup_addr;
+extern GHashTable *db_lookup_vlan_networkid;
+extern GHashTable *db_lookup_addr_ifindex;
+
+
+void stats_send_link(gpointer key, gpointer value, gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    char time_str[128];
+    GList *iter;
+
+    struct link_cache *link = (struct link_cache *)value;
+    char mac_str[MAC_ADDR_STR_LEN];
+    mac_to_string((unsigned char *)mac_str, link->mac, MAC_ADDR_STR_LEN);
+
+    jsonw_start_object(jw);
+
+    jsonw_string_field(jw, "ifname", link->ifname);
+    jsonw_uint_field(jw, "link_ifindex", link->link_ifindex);
+    jsonw_string_field(jw, "mac", mac_str);
+    jsonw_string_field(jw, "kind", link->kind);
+    jsonw_string_field(jw, "slave_kind", link->slave_kind);
+    jsonw_uint_field(jw, "vlan_protocol", link->vlan_protocol);
+    jsonw_uint_field(jw, "vlan_id", link->vlan_id);
+    jsonw_bool_field(jw, "has_vlan", link->has_vlan);
+    jsonw_bool_field(jw, "is_svi", link->is_svi);
+    jsonw_bool_field(jw, "is_macvlan", link->is_macvlan);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&link->times.created.tv_sec));
+    jsonw_string_field(jw, "created", time_str);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&link->times.referenced.tv_sec));
+    jsonw_string_field(jw, "referenced", time_str);
+
+    jsonw_name(jw, "networks");
+    jsonw_start_array(jw);
+
+    // List network_list
+    iter = link->network_list;
+    while (iter != NULL) {
+        struct link_network_cache *ln = (struct link_network_cache *)iter->data;
+
+        jsonw_start_object(jw);
+
+        jsonw_uint_field(jw, "id", ln->network->id);
+        jsonw_string_field(jw, "network_str", ln->network->network_str);
+        jsonw_uint_field(jw, "prefixlen", ln->network->prefixlen);
+
+        jsonw_end_object(jw);
+
+        iter = g_list_next(iter);
+    }
+
+    jsonw_end_array(jw);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_links(json_writer_t *jw)
+{
+    jsonw_name(jw, "links");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_link_cache, stats_send_link, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_network(gpointer key, gpointer value, gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    char time_str[128];
+    GList *iter;
+
+    struct network_cache *network = (struct network_cache *)value;
+
+    jsonw_start_object(jw);
+
+    jsonw_uint_field(jw, "id", network->id);
+    jsonw_string_field(jw, "network", network->network_str);
+    jsonw_uint_field(jw, "prefixlen", network->prefixlen);
+    jsonw_uint_field(jw, "true_prefixlen", network->true_prefixlen);
+    jsonw_uint_field(jw, "refcnt", network->refcnt);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&network->times.created.tv_sec));
+    jsonw_string_field(jw, "created", time_str);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&network->times.referenced.tv_sec));
+    jsonw_string_field(jw, "referenced", time_str);
+
+    jsonw_name(jw, "links");
+    jsonw_start_array(jw);
+
+    // List link_list
+    iter = network->links;
+    while (iter != NULL) {
+        char ip_str[INET6_ADDRSTRLEN];
+        struct link_network_cache *ln = (struct link_network_cache *)
+            iter->data;
+
+        format_ip_address(ip_str, sizeof(ip_str), &ln->ip);
+
+        jsonw_start_object(jw);
+
+        jsonw_string_field(jw, "ifname", ln->link->ifname);
+        jsonw_string_field(jw, "ip", ip_str);
+
+        jsonw_end_object(jw);
+
+        iter = g_list_next(iter);
+    }
+
+    jsonw_end_array(jw);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_networks(json_writer_t *jw)
+{
+    jsonw_name(jw, "networks");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_network_cache, stats_send_network, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_fdb(gpointer key, gpointer value, gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    char mac_str[MAC_ADDR_STR_LEN];
+    char time_str[128];
+    struct fdb_cache *fdb = (struct fdb_cache *)value;
+
+    mac_to_string((unsigned char *)mac_str, fdb->mac, MAC_ADDR_STR_LEN);
+
+    jsonw_start_object(jw);
+
+    jsonw_string_field(jw, "mac", mac_str);
+    jsonw_uint_field(jw, "ifindex", fdb->link->ifindex);
+    jsonw_uint_field(jw, "vlan_id", fdb->vlan_id);
+
+    jsonw_uint_field(jw, "reference_count", fdb->reference_count);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&fdb->times.created.tv_sec));
+    jsonw_string_field(jw, "created", time_str);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&fdb->times.referenced.tv_sec));
+    jsonw_string_field(jw, "referenced", time_str);
+
+    jsonw_end_object(jw);
+}
+
+
+void stats_send_fdbs(json_writer_t *jw)
+{
+    jsonw_name(jw, "fdb");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_fdb_cache, stats_send_fdb, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_neigh(gpointer key, gpointer value, gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    char time_str[128];
+    struct neigh_cache *neigh = (struct neigh_cache *)value;
+    char mac_str[MAC_ADDR_STR_LEN];
+
+    mac_to_string((unsigned char *)mac_str, neigh->mac, MAC_ADDR_STR_LEN);
+
+    jsonw_start_object(jw);
+
+    jsonw_uint_field(jw, "ifindex", neigh->ifindex);
+    jsonw_string_field(jw, "mac", mac_str);
+    jsonw_string_field(jw, "ip", neigh->ip_str);
+    switch (neigh->nud_state) {
+    case NUD_INCOMPLETE:
+        jsonw_string_field(jw, "nud_state", "incomplete");
+        break;
+    case NUD_REACHABLE:
+        jsonw_string_field(jw, "nud_state", "reachable");
+        break;
+    case NUD_STALE:
+        jsonw_string_field(jw, "nud_state", "stale");
+        break;
+    case NUD_DELAY:
+        jsonw_string_field(jw, "nud_state", "delay");
+        break;
+    case NUD_PROBE:
+        jsonw_string_field(jw, "nud_state", "probe");
+        break;
+    case NUD_FAILED:
+        jsonw_string_field(jw, "nud_state", "failed");
+        break;
+    case NUD_NOARP:
+        jsonw_string_field(jw, "nud_state", "noarp");
+        break;
+    case NUD_PERMANENT:
+        jsonw_string_field(jw, "nud_state", "permanent");
+        break;
+    default:
+        jsonw_string_field(jw, "nud_state", "unknown");
+        break;
+    }
+    jsonw_uint_field(jw, "update_count", neigh->update_count);
+    jsonw_uint_field(jw, "reference_count", neigh->reference_count);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&neigh->times.created.tv_sec));
+    jsonw_string_field(jw, "created", time_str);
+
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S",
+             localtime(&neigh->times.referenced.tv_sec));
+    jsonw_string_field(jw, "referenced", time_str);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_neighs(json_writer_t *jw)
+{
+    jsonw_name(jw, "neighs");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_neigh_cache, stats_send_neigh, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_lookup_addr_entry(gpointer key, gpointer value, gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    struct in6_addr *addr = (struct in6_addr *)key;
+    struct network_cache *network = (struct network_cache *)value;
+    char ip_str[INET6_ADDRSTRLEN];
+
+    format_ip_address(ip_str, sizeof(ip_str), addr);
+
+    jsonw_start_object(jw);
+
+    jsonw_name(jw, "key");
+    jsonw_start_object(jw);
+    jsonw_string_field(jw, "ip", ip_str);
+    jsonw_end_object(jw);
+
+    jsonw_uint_field(jw, "network_id", network->id);
+    jsonw_string_field(jw, "network", network->network_str);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_lookup_addr(json_writer_t *jw)
+{
+    jsonw_name(jw, "lookup_addr");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_lookup_addr, stats_send_lookup_addr_entry, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_lookup_vlan_networkid_entry(gpointer key, gpointer value,
+                                            gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    struct vlan_networkid_cache_key *key_entry =
+        (struct vlan_networkid_cache_key *)key;
+    struct link_network_cache *link_net = (struct link_network_cache *)value;
+    char value_ip_str[INET6_ADDRSTRLEN];
+
+    format_ip_address(value_ip_str, sizeof(value_ip_str), &link_net->ip);
+
+    jsonw_start_object(jw);
+
+    jsonw_name(jw, "key");
+    jsonw_start_object(jw);
+    jsonw_uint_field(jw, "vlan_id", key_entry->vlan_id);
+    jsonw_uint_field(jw, "network_id", key_entry->network_id);
+    jsonw_end_object(jw);
+
+    jsonw_name(jw, "value");
+    jsonw_start_object(jw);
+    jsonw_string_field(jw, "ip", value_ip_str);
+    jsonw_string_field(jw, "ifname", link_net->link->ifname);
+    jsonw_uint_field(jw, "network_id", link_net->network->id);
+    jsonw_end_object(jw);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_lookup_vlan_networkid(json_writer_t *jw)
+{
+    jsonw_name(jw, "lookup_vlan_networkid");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_lookup_vlan_networkid,
+                         stats_send_lookup_vlan_networkid_entry, jw);
+
+    jsonw_end_array(jw);
+}
+
+void stats_send_lookup_addr_ifindex_entry(gpointer key, gpointer value,
+                                          gpointer user_data)
+{
+    json_writer_t *jw = (json_writer_t *)user_data;
+    struct ifindex_addr_cache_key *key_entry = (struct ifindex_addr_cache_key *)key;
+    struct link_network_cache *link_net = (struct link_network_cache *)value;
+    char key_ip_str[INET6_ADDRSTRLEN];
+    char value_ip_str[INET6_ADDRSTRLEN];
+
+    format_ip_address(key_ip_str, sizeof(key_ip_str), &key_entry->network_ip);
+    format_ip_address(value_ip_str, sizeof(value_ip_str), &link_net->ip);
+
+    jsonw_start_object(jw);
+
+    jsonw_name(jw, "key");
+    jsonw_start_object(jw);
+    jsonw_uint_field(jw, "ifindex", key_entry->ifindex);
+    jsonw_string_field(jw, "network_ip", key_ip_str);
+    jsonw_end_object(jw);
+
+    jsonw_name(jw, "value");
+    jsonw_start_object(jw);
+    jsonw_string_field(jw, "ip", value_ip_str);
+    jsonw_string_field(jw, "ifname", link_net->link->ifname);
+    jsonw_uint_field(jw, "network_id", link_net->network->id);
+    jsonw_end_object(jw);
+
+    jsonw_end_object(jw);
+}
+
+void stats_send_lookup_addr_ifindex(json_writer_t *jw)
+{
+    jsonw_name(jw, "lookup_addr_ifindex");
+    jsonw_start_array(jw);
+
+    g_hash_table_foreach(db_lookup_addr_ifindex,
+                         stats_send_lookup_addr_ifindex_entry, jw);
+
+    jsonw_end_array(jw);
+}
+
+int handle_stats_server_request(void)
+{
+    int err = 0;
+    int flags;
+    int memfd_writer_fd;
+    FILE *client;
+
+    env.stats_client_fd = accept(env.stats_server_fd, NULL, NULL);
+    if (env.stats_client_fd == -1) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK)
+            goto out;
+        pr_err(errno, "accept");
+        err = errno;
+        goto out;
+    }
+
+    // Set the client socket to non-blocking mode
+    flags = fcntl(env.stats_client_fd, F_GETFL, 0);
+    fcntl(env.stats_client_fd, F_SETFL, flags | O_NONBLOCK);
+
+    // Create a memfd
+    env.memfd_fd = memfd_create("json_stats", MFD_ALLOW_SEALING);
+    if (env.memfd_fd == -1) {
+        perror("memfd_create");
+        err = -errno;
+        goto out;
+    }
+
+    // Prepare the memfd for writing
+    memfd_writer_fd = dup(env.memfd_fd);
+    client = fdopen(memfd_writer_fd, "w");
+    if (client == NULL) {
+        pr_err(errno, "fdopen");
+        err = -errno;
+        goto out;
+    }
+
+    // Add JSON data to the memfd
+    json_writer_t *wr = jsonw_new(client);
+    jsonw_pretty(wr, true);
+
+    jsonw_start_object(wr);
+
+    stats_send_links(wr);
+    stats_send_networks(wr);
+    stats_send_fdbs(wr);
+    stats_send_neighs(wr);
+    stats_send_lookup_addr(wr);
+    stats_send_lookup_vlan_networkid(wr);
+    stats_send_lookup_addr_ifindex(wr);
+
+    jsonw_end_object(wr);
+    jsonw_destroy(&wr);
+
+    fclose(client);
+
+out:
+    return err;
+}
+
+
+int setup_stats(void)
+{
+    int err = 0;
+    int flags;
+    struct sockaddr_un addr;
+
+    // memfd file descriptor
+    env.number_of_fds++;
+
+    env.stats_server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (env.stats_server_fd == -1) {
+        perror("socket");
+        err = -errno;
+        goto out;
+    }
+    env.number_of_fds++; // Add one for the server socket
+    env.number_of_fds++; // Add one for the client socket
+
+    // Set up the socket address
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, STATS_SOCKET_PATH, sizeof(addr.sun_path) - 1);
+
+    // Remove any existing socket file and bind to the address
+    unlink(STATS_SOCKET_PATH);
+    if (bind(env.stats_server_fd, (struct sockaddr*)&addr,
+             sizeof(struct sockaddr_un)) == -1) {
+        perror("bind");
+        err = -errno;
+        goto out;
+    }
+
+    // Listen for incoming connections
+    if (listen(env.stats_server_fd, 1) == -1) {
+        perror("listen");
+        err = -errno;
+        goto out;
+    }
+
+    // Set the listening socket to non-blocking mode
+    flags = fcntl(env.stats_server_fd, F_GETFL, 0);
+    fcntl(env.stats_server_fd, F_SETFL, flags | O_NONBLOCK);
+
+out:
+    return err;
+}
+
+void cleanup_stats(void)
+{
+    close(env.stats_server_fd);
+    unlink(STATS_SOCKET_PATH);
+}


### PR DESCRIPTION
This git commit changes the neighsnoopd to become fully event-driven using epoll and fully cached. The new event system is still single-threaded; however, the events that epoll handles are as follows:

- We monitor Netlink for all kernel RTMGRP_IPV4_IFADDR, RTMGRP_IPV6_IFADDR, RTMGRP_LINK, RTMGRP_NEIGH events. This change allows neighsnoopd to track and cache changes instead of doing lookups.

- We cache all relevant information about links, the relevant subnets, the bridge FDB, and the neighbor entries on the subnets we monitor.

- We send gratuitous ARP/NS to neighbors where the NUD state becomes stale. For now, this is reactive, but we would like to have timers to make it proactive in the future.

- All eBPF ringbuffer events are epoll events. We also use the LPM TRIE data structure to filter out ARP/NS that are not destined for our target subnets.

- We have introduced a trivial client program that shows the cache's status in JSON format. The neighsnoopd accepts clients using a Unix Socket and can only handle one client at a time. For now, this client mechanism is mainly intended for debugging. In the future, the client should be able to notify the neighsnoopd that it only wants a subset of the data and display it in a much more convenient format.

- Signal handling is now handled as events. A future goal for signal handling is to trigger functionality, such as forcing rereading all the Netlink entries or rereading a potential config file.